### PR TITLE
TCDTF Italy Fix

### DIFF
--- a/common/ideas/italy.txt
+++ b/common/ideas/italy.txt
@@ -3539,7 +3539,7 @@ ideas = {
 				naval_equipment = 0.15
 			}
 			
-			traits = { raiding_fleet_naval_manufacturer }	#build mostly light vehicles, carried traits from r56 - Fantom
+			traits = { battlefleet_designer }	#build focused around battlefield set back to vanialla - EndSieg
 		}
 
 		ITA_crda_improved = { #NORTH
@@ -3565,12 +3565,20 @@ ideas = {
 				naval_equipment = 0.15
 			}
 			
-			traits = { raiding_fleet_naval_manufacturer }
+			traits = { battlefleet_designer }
 
 			equipment_bonus = {
-				submarine = {
+				capital_ship = {
 					instant = yes
-					build_cost_ic = -0.1
+					build_cost_ic = -0.2
+				}
+				screen_ship = {
+					instant = yes
+					build_cost_ic = -0.2
+				}
+				submarine = {
+					instant = yes 
+					build_cost_ic = 0.3
 				}
 			}
 		}
@@ -3631,6 +3639,7 @@ ideas = {
 			modifier = {
 				naval_equipment_upgrade_xp_cost = -0.25
 				refit_speed = 0.15
+				refit_ic_cost = -0.1
 				repair_speed_factor = 0.1
 			}
 		}
@@ -3693,6 +3702,10 @@ ideas = {
 					instant = yes
 					build_cost_ic = -0.1
 				}
+				light_cruiser = {
+					instant = yes
+					build_cost_ic = -0.1
+				}
 			}
 		}
 
@@ -3750,7 +3763,8 @@ ideas = {
 			traits = { raiding_fleet_naval_manufacturer }
 
 			modifier = {
-				spotting_chance = 0.05
+				spotting_chance = 0.1
+				convoy_raiding_efficiency = 0.1
 			}
 		}
 
@@ -3806,6 +3820,13 @@ ideas = {
 			}
 			
 			traits = { submarine_manufacturer_2 }
+
+			equipment_bonus = {
+				submarine = {
+					instant = yes
+					build_cost_ic = -0.15
+				}
+			}
 		}
 	}
 	
@@ -3920,7 +3941,7 @@ ideas = {
 
 			modifier = {
 				air_equipment_upgrade_xp_cost = -0.25
-				air_mission_efficiency = 0.03
+				air_mission_efficiency = 0.05
 			}
 
 			research_bonus = {
@@ -4492,16 +4513,30 @@ ideas = {
 		}
 
 		ITA_officine_meccaniche = { #Could be North (Milano) -> Considered anywhere
-			picture = ITA_officine_meccaniche	#replaced vanilla designer
+			picture = ITA_officine_meccaniche	#restored vanialla designer - EndSieg
 			
 			allowed = {
 				original_tag = ITA
 			}
+			available ={
+				has_completed_focus = ITA_new_ricostruzione_industriale
+			}
 			research_bonus = {
-				armor = 0.05
+				motorized_equipment = 0.2
+			}
+
+			equipment_bonus = {
+				motorized_equipment = {
+					instant = yes
+					build_cost_ic = -0.15
+				}
+				mechanized_equipment = {
+					instant = yes
+					build_cost_ic = -0.15
+				}
 			}
 			
-			traits = { small_tank_producer_offense_1 }
+			traits = { motorized_equipment_manufacturer }
 		}
 	}
 
@@ -4705,7 +4740,7 @@ ideas = {
 			traits = { construction_company }
 
 			modifier = {
-				production_speed_buildings_factor = 0.05
+				production_speed_buildings_factor = 0.1
 			}
 		}
 

--- a/common/national_focus/italy.txt
+++ b/common/national_focus/italy.txt
@@ -5490,12 +5490,12 @@ focus_tree = {
 				limit = {
 					has_dlc = "By Blood Alone"
 				}
-				has_tech = improved_small_airframe
-				has_tech = improved_medium_airframe
+				#has_tech = improved_small_airframe
+				#has_tech = improved_medium_airframe
 			}
 			else = {
-				has_tech = fighter2
-				has_tech = tactical_bomber2
+				#has_tech = fighter2
+				#has_tech = tactical_bomber2
 			}
 		}
 


### PR DESCRIPTION
-Sets Designers Back to Vanilla to restore choices back to ITA. 
-Removes another Starting old techs from ITA PRE BBA AIR