### PR TITLE
TCDTF Dockyard Button

### DIFF
--- a/common/game_rules/00_game_rules.txt
+++ b/common/game_rules/00_game_rules.txt
@@ -2797,6 +2797,22 @@ select_host_country = {
 	}
 }
 
+dockyard_botton_selection = {
+	name = "DOCKYARD_BUTTON_SELECTION"
+	group = "HOST_OPTIONS"
+	default = {
+		name = DISABLED
+		text = "DISABLED"
+		desc = "DOCKYARD_BUTTON_DISABLED_DESC"
+	}
+	option = {
+		name = ENABLED
+		text = "ENABLED"
+		desc = "DOCKYARD_BUTTON_ENABLED_DESC"
+		allow_achievements = yes						  
+	}
+}
+
 
 ###---> Foreign Policy <><> <><> <><>
 

--- a/common/scripted_diplomatic_actions/send_dockyard.txt
+++ b/common/scripted_diplomatic_actions/send_dockyard.txt
@@ -6,11 +6,8 @@ scripted_diplomatic_actions = {
 				option = ENABLED
 			}
 			THIS = {
-				AND = {
-					NOT= {
-						has_war_with = ROOT
-					}
-					is_ai = no
+				NOT= {
+					has_war_with = ROOT
 				}
 			}
 			ROOT = {
@@ -24,13 +21,16 @@ scripted_diplomatic_actions = {
 				any_owned_state = { is_controlled_by = PREV dockyard > 0 }
 			}
 			THIS = {
-				any_core_state = {
-					is_coastal = yes
-					free_building_slots = {
-						building = dockyard
-						size > 0
-						include_locked = no
+				AND = {
+					any_core_state = {
+						is_coastal = yes
+						free_building_slots = {
+							building = dockyard
+							size > 0
+							include_locked = no
+						}
 					}
+					is_ai = no
 				}
 			}
 		}

--- a/common/scripted_diplomatic_actions/send_dockyard.txt
+++ b/common/scripted_diplomatic_actions/send_dockyard.txt
@@ -1,0 +1,93 @@
+scripted_diplomatic_actions = {
+	send_dockyard= {
+		visible = {
+			has_game_rule = {
+				rule = dockyard_botton_selection
+				option = ENABLED
+			}
+			THIS = {
+				NOT= {
+					has_war_with = ROOT
+				}
+			}
+			ROOT = {
+				NOT = {
+					has_war = yes
+				}
+			}
+		}
+		selectable = { 
+			ROOT = {
+				any_owned_state = { is_controlled_by = PREV dockyard > 0 }
+			}
+			THIS = {
+				any_core_state = {
+					is_coastal = yes
+					free_building_slots = {
+						building = dockyard
+						size > 0
+						include_locked = no
+					}
+				}
+			}
+		}
+		
+		requires_acceptance = no
+		cost = 0 
+		command_power = 0
+		
+		show_acceptance_on_action_button = no
+		
+		icon = 4 
+		
+		on_sent_effect = {}
+		
+		complete_effect = {
+			ROOT={random_owned_controlled_state = {limit={dockyard > 0} remove_building = {type=dockyard level = 1}}}
+			
+			random_core_state = {
+				limit = {
+					is_coastal = yes
+					free_building_slots = {
+						building = dockyard
+						size > 0
+						include_locked = no
+					}
+				}
+				add_building_construction = {
+					type = dockyard
+					level = 1
+					instant_build = yes
+				}
+			}	
+		}
+		
+		reject_effect = {
+		
+		}
+		
+		send_description = send_dockyard_send_text
+		
+		receive_description =send_dockyard_get_message
+		
+		accept_title =send_dockyard_get_title
+		
+		accept_description =send_dockyard_get_message
+		
+		reject_title =send_dockyard_get_title
+		
+		reject_description =send_dockyard_get_message
+		
+		ai_acceptance = {
+		condition = {
+		base =0
+		
+		}
+		}
+		
+		ai_desire = {
+		base = -1
+		
+		}
+	}
+	}

--- a/common/scripted_diplomatic_actions/send_dockyard.txt
+++ b/common/scripted_diplomatic_actions/send_dockyard.txt
@@ -6,8 +6,11 @@ scripted_diplomatic_actions = {
 				option = ENABLED
 			}
 			THIS = {
-				NOT= {
-					has_war_with = ROOT
+				AND = {
+					NOT= {
+						has_war_with = ROOT
+					}
+					is_ai = no
 				}
 			}
 			ROOT = {

--- a/localisation/english/replace/r56_game_rules_l_english.yml
+++ b/localisation/english/replace/r56_game_rules_l_english.yml
@@ -645,4 +645,10 @@
  HIST_POLAND:0 "Force Hist Path"
  HIST_POLAND_DESC:0 "Only allows Polish historical path"
 
+ DOCKYARD_BUTTON_SELECTION:0 "Send Dockyard Button"
+ ENABLED:0 "Enabled"
+ DOCKYARD_BUTTON_ENABLED_DESC:0 "Enables the option to send dockyards to other countries"
+ DISABLED:0 "Disabled"
+ DOCKYARD_BUTTON_DISABLED_DESC:0 "Disables the option to send dockyards to other countries"
+
  #####-----> End of File <><> <><> <><> <><> <><>

--- a/localisation/english/send_dockyard_l_english.yml
+++ b/localisation/english/send_dockyard_l_english.yml
@@ -1,0 +1,10 @@
+﻿l_english:
+SEND_DOCKYARD_TITLE:0 "Send Dockyard"
+SEND_DOCKYARD_ACTION_DESC:0 "SEND ONE DOCKYARD TO THE TARGETED COUNTRY"
+send_dockyard_send_text:0 "Are you sure you want to send one dockyard to this nation?"
+send_dockyard_get_message:0 "[FROM.GetNameDEF] sent one dockyard to us"
+send_dockyard_get_title:0 "Recieved Dockyard"
+a:0 "a"
+a:0 "a"
+a:0 "a"
+a:0 "a"


### PR DESCRIPTION
-adds the ability to send dockyards to other countries in the same way the send civ button works
-added game rule to enable or disable the send dockyard button
(***IMPORTANT: I could not test the received dockyard message as it is impossible to send to yourself. As this is a small part of the  functionality and it works fine on the send civ button, I will assume it works and will test after pushed to live to see if any changes need to be made***)

I would like all of you to test every scenario and see if this can get bugged in any way. Thanks!