### PR TITLE
Poland Rebalance

### DIFF
--- a/common/ai_strategy/POL.txt
+++ b/common/ai_strategy/POL.txt
@@ -22,6 +22,11 @@ POL_unit_production = {
 	}
 
 	ai_strategy = {
+		type = air_factory_balance
+		value = -100
+	}
+
+	ai_strategy = {
 		type = build_army
 		id = infantry
 		value = 100
@@ -92,19 +97,13 @@ POL_unit_production = {
 	ai_strategy = {
 		type = unit_ratio
 		id = fighter
-		value = 30
+		value = -100
 	}
 	
 	ai_strategy = {
 		type = unit_ratio
 		id = cas
-		value = 15 #because doctrine this = 15
-	}
-	
-	ai_strategy = {
-		type = unit_ratio
-		id = tactical_bomber
-		value = 5
+		value = 1 #because doctrine this = 15
 	}
 	
 	ai_strategy = {
@@ -117,12 +116,6 @@ POL_unit_production = {
 		type = unit_ratio
 		id = naval_bomber
 		value = -25
-	}
-	
-	ai_strategy = {
-		type = equipment_production_factor
-		id = fighter
-		value = 10
 	}
 
 	ai_strategy = {
@@ -159,11 +152,11 @@ POL_unit_production = {
 		id = artillery
 		value = 2
 	}
-	#ai_strategy = {
-	#	type = equipment_production_min_factories
-	#	id = fighter
-	#	value = 3
-	#}
+	ai_strategy = {
+		type = equipment_production_min_factories
+		id = fighter
+		value = 4
+	}
 	ai_strategy = {
 		type = equipment_variant_production_factor
 		id = large_plane_airframe

--- a/common/ai_strategy/default.txt
+++ b/common/ai_strategy/default.txt
@@ -250,6 +250,7 @@ bba_air_prod_1 = {
 		always = yes
 		NOT = { original_tag = GER } 
 		NOT = { original_tag = ENG }
+		NOT = { original_tag = POL }
 	}
 
 	abort_when_not_enabled = yes

--- a/common/on_actions/pol_on_actions.txt
+++ b/common/on_actions/pol_on_actions.txt
@@ -46,7 +46,7 @@ on_actions = {
 					load_oob = "POL_1936_ai"
 					add_equipment_to_stockpile = {
 						type = artillery_equipment_1
-						amount = 800
+						amount = 400
 						producer = POL
 					}
 					
@@ -70,7 +70,7 @@ on_actions = {
 					
 					add_equipment_to_stockpile = {
 						type = support_equipment_1
-						amount = 150
+						amount = 200
 						producer = POL
 					}
 				}

--- a/history/units/POL_1936_ai.txt
+++ b/history/units/POL_1936_ai.txt
@@ -60,8 +60,9 @@ division_template = {
 		artillery_brigade = { x = 3 y = 0 }
 	}
 	support = {
-        engineer = { x = 0 y = 0 }
-        artillery = { x = 0 y = 1 }
+        engineer = { x = 0 y = 1 }
+        artillery = { x = 0 y = 2 }
+		anti_air = { x = 0 y = 3 }
 	}
 }
 division_template = {

--- a/history/units/POL_1936_ai.txt
+++ b/history/units/POL_1936_ai.txt
@@ -204,15 +204,15 @@ units = {
 	division= {	#Garrisoned at Lublin
 		name = "2 Grupa Artylerii"
 		location = 11399
-		division_template = "Grupa Artylerii"
+		division_template = "Korpus Ochrony Pogranicza"
 		force_equipment_variants = { infantry_equipment_0 = { owner = "POL" } }
 		start_experience_factor = 0.45
-		start_equipment_factor = 0.8 #0.3
+		start_equipment_factor = 0.6 #0.3
 	}
 	division= {	#Garrisoned at Grodno
 		name = "3 Grupa Artylerii"
 		location = 3393
-		division_template = "Grupa Artylerii"
+		division_template = "Korpus Ochrony Pogranicza"
 		force_equipment_variants = { infantry_equipment_0 = { owner = "POL" } }
 		start_experience_factor = 0.45
 		start_equipment_factor = 0.6 #0.3
@@ -220,31 +220,31 @@ units = {
 	division= {	#Garrisoned at Lodz 
 		name = "4 Grupa Artylerii"
 		location = 9508
-		division_template = "Grupa Artylerii"
+		division_template = "Korpus Ochrony Pogranicza"
 		force_equipment_variants = { infantry_equipment_0 = { owner = "POL" } }
 		start_experience_factor = 0.45
-		start_equipment_factor = 0.8 #0.3
+		start_equipment_factor = 0.7 #0.3
 	}
 	division= {	#Garrisoned at Krakow
 		name = "5 Grupa Artylerii"
 		location = 9427
-		division_template = "Grupa Artylerii"
+		division_template = "Korpus Ochrony Pogranicza"
 		force_equipment_variants = { infantry_equipment_0 = { owner = "POL" } }
 		start_experience_factor = 0.45
-		start_equipment_factor = 0.8 #0.3
+		start_equipment_factor = 0.6 #0.3
 	}
 	division= {	#Garrisoned at Lviv
 		name = "6 Grupa Artylerii"
 		location = 11479
-		division_template = "Grupa Artylerii"
+		division_template = "Korpus Ochrony Pogranicza"
 		force_equipment_variants = { infantry_equipment_0 = { owner = "POL" } }
 		start_experience_factor = 0.45
-		start_equipment_factor = 0.8 #0.3
+		start_equipment_factor = 0.6 #0.3
 	}
 	division= {	#Garrisoned at Poznan
 		name = "7 Grupa Artylerii"
 		location = 6558
-		division_template = "Grupa Artylerii"
+		division_template = "Korpus Ochrony Pogranicza"
 		force_equipment_variants = { infantry_equipment_0 = { owner = "POL" } }
 		start_experience_factor = 0.45
 		start_equipment_factor = 0.6 #0.3
@@ -252,18 +252,18 @@ units = {
 	division= {	#Garrisoned at Torun, Pomerania
 		name = "8 Grupa Artylerii"
 		location = 3295
-		division_template = "Grupa Artylerii"
+		division_template = "Korpus Ochrony Pogranicza"
 		force_equipment_variants = { infantry_equipment_0 = { owner = "POL" } }
 		start_experience_factor = 0.45
-		start_equipment_factor = 0.8 #0.3
+		start_equipment_factor = 0.6 #0.3
 	}
 	division= {	#Garrisoned at Brest
 		name = "9 Grupa Artylerii"
 		location = 3392
-		division_template = "Grupa Artylerii"
+		division_template = "Korpus Ochrony Pogranicza"
 		force_equipment_variants = { infantry_equipment_0 = { owner = "POL" } }
 		start_experience_factor = 0.45
-		start_equipment_factor = 0.8 #0.3
+		start_equipment_factor = 0.7 #0.3
 	}
 	division= {	#Garrisoned at Przemysl
 		name = "10 Grupa Artylerii"

--- a/history/units/POL_1936_air_bba.txt
+++ b/history/units/POL_1936_air_bba.txt
@@ -3,23 +3,17 @@
 ##### Wojska Lotnicze i Obrony Powietrzne #####
 air_wings = {
 	10 = { 
-		small_plane_airframe_0 =  { owner = "POL" amount = 34 version_name = "PZL P.11" }
-		small_plane_airframe_0 =  { owner = "POL" amount = 26 version_name = "PZL P.24" }
+		small_plane_airframe_0 =  { owner = "POL" amount = 100 version_name = "PZL P.11" }
 	}
 	86 = { 
 		small_plane_airframe_0 =  {
 			owner = "POL" 
-			amount = 54
+			amount = 100
 			version_name = "PZL P.24"
 		}
 		small_plane_cas_airframe_1 =  {
 			owner = "POL" 
-			amount = 64
-			version_name = "PZL P.23"
-		}
-		small_plane_cas_airframe_1 =  {
-			owner = "POL" 
-			amount = 32
+			amount = 100
 			version_name = "PZL P.23"
 		}
 	}
@@ -35,17 +29,7 @@ instant_effect = {
 			creator = "POL"
 			version_name = "PZL P.24"
 		}
-		requested_factories = 1
-		progress = 0.20
-		efficiency = 100
-	}
-	add_equipment_production = {
-		equipment = {
-			type = small_plane_cas_airframe_1
-			creator = "POL"
-			version_name = "PZL P.23"
-		}
-		requested_factories = 1
+		requested_factories = 4
 		progress = 0.20
 		efficiency = 100
 	}

--- a/history/units/POL_1936_player.txt
+++ b/history/units/POL_1936_player.txt
@@ -67,7 +67,6 @@ division_template = {
 	}
 	support = {
         recon = { x = 0 y = 0 }
-		anti_air = { x = 0 y = 1 }
 	}
 }
 division_template = {

--- a/history/units/POL_1936_player.txt
+++ b/history/units/POL_1936_player.txt
@@ -67,6 +67,7 @@ division_template = {
 	}
 	support = {
         recon = { x = 0 y = 0 }
+		anti_air = { x = 0 y = 1 }
 	}
 }
 division_template = {


### PR DESCRIPTION
-changed some starting division's equipment factor(slightly less)
-changed a few OP starting div templates to "default" templates (less arty, small increase in inf)
-nerfed total starting arty from 3.3K to 2.3K at START (33% NERF)
-added support aa to one template to use up some wasted stockpile (800k un-used in aug 38) (AI would produce for some reason not ever use in template)
-merged air wings (200 fighters, 100 CAS TOTAL (prevents Ai from wasting mills on air)(small round up))
-made Poland only have four mils on air the entire game
-slightly increased supp equip (200 from 150) (still has 400 deficit at the start)