### PR TITLE
Russia Advisors fixed for 56 tree

### DIFF
--- a/common/characters/SOV.txt
+++ b/common/characters/SOV.txt
@@ -4145,17 +4145,22 @@ characters = {
 				OR = {
 					has_global_flag = SOV_soviet_civil_war
 					has_global_flag = SOV_soviet_civil_war_over
+					has_completed_focus = SOV_form_a_fifth_column_old
 				}
 				OR = {
 					has_completed_focus = SOV_integrate_smirnovs_bloc
 					has_completed_focus = SOV_return_democracy_to_the_party
+					has_completed_focus = SOV_form_a_fifth_column_old
 				}
 				is_country_leader = no
 				if = {
 					limit = {
 						has_character_flag = SOV_exiled_flag
 					}
-					NOT = { has_character_flag = SOV_exiled_flag }
+					OR = {
+						has_completed_focus = SOV_form_a_fifth_column_old
+					NOT = 	{has_character_flag = SOV_exiled_flag}
+					}
 				}
 				IF = {
 					limit = {
@@ -4198,7 +4203,7 @@ characters = {
 			}
 		}
 
-		advisor = {
+		advisor = {   #advisorfix
 			slot = political_advisor
 			idea_token = SOV_ivan_smirnov
 			allowed = {
@@ -4212,9 +4217,11 @@ characters = {
 				OR = {
 					has_global_flag = SOV_soviet_civil_war
 					has_global_flag = SOV_soviet_civil_war_over
+					has_completed_focus = SOV_form_a_fifth_column_old
 				}
 				OR = {
-					has_completed_focus = SOV_integrate_smirnovs_bloc
+					has_completed_focus = SOV_form_a_fifth_column_old
+					has_completed_focus = SOV_integrate_smirnovs_bloc 
 					has_completed_focus = SOV_return_democracy_to_the_party
 				}
 				is_country_leader = no
@@ -4222,7 +4229,11 @@ characters = {
 					limit = {
 						has_character_flag = SOV_imprisoned_flag
 					}
-					NOT = { has_character_flag = SOV_imprisoned_flag } #For flavor purposes only -> Removed in the appropriate focus/event/dec
+					OR = {
+						has_completed_focus = SOV_form_a_fifth_column_old
+					NOT = 	{has_character_flag = SOV_imprisoned_flag}
+					}
+
 				}
 				if = {
 					limit = {
@@ -4276,18 +4287,25 @@ characters = {
 				OR = {
 					has_completed_focus = SOV_integrate_smirnovs_bloc
 					has_completed_focus = SOV_return_democracy_to_the_party
+					has_completed_focus = SOV_form_a_fifth_column_old
 				}
 				if = {
 					limit = {
 						has_character_flag = SOV_imprisoned_flag
 					}
-					NOT = { has_character_flag = SOV_imprisoned_flag } #For flavor purposes only -> Removed in the appropriate focus/event/dec
+					OR = {
+						has_completed_focus = SOV_form_a_fifth_column_old
+					NOT = 	{has_character_flag = SOV_imprisoned_flag}
+					} #For flavor purposes only -> Removed in the appropriate focus/event/dec
 				}
 				if = {
 					limit = {
 						has_character_flag = SOV_exiled_flag
 					}
-					NOT = { has_character_flag = SOV_exiled_flag }
+					OR = {
+						has_completed_focus = SOV_form_a_fifth_column_old
+					NOT = 	{has_character_flag = SOV_exiled_flag}
+					}
 				}
 				#used to showcase the player that those guys would die in case of a purge  - Fantom
 				NOT = {
@@ -4345,7 +4363,7 @@ characters = {
 					limit = {
 						has_global_flag = sov_old_focus_tree
 					}
-					has_completed_focus = SOV_trotskyite_victory
+					has_completed_focus = SOV_form_a_fifth_column_old
 				}
 				else = {
 					OR = {
@@ -4386,6 +4404,7 @@ characters = {
 
 		allowed_civil_war = {
 			OR = {
+				has_completed_focus = SOV_form_a_fifth_column_old
 				AND = {
 					tag = SOV
 					SOV_is_left_opposition = yes 
@@ -4416,6 +4435,7 @@ characters = {
 			}
 			available = {
 				OR = {
+					has_completed_focus = SOV_form_a_fifth_column_old
 					AND = {
 						tag = SOV
 						SOV_is_left_opposition = yes 
@@ -4431,7 +4451,10 @@ characters = {
 					limit = {
 						has_character_flag = SOV_exiled_flag
 					}
-					NOT = { has_character_flag = SOV_exiled_flag }
+					OR = {
+						has_completed_focus = SOV_form_a_fifth_column_old
+					NOT = 	{has_character_flag = SOV_exiled_flag}
+					}
 				}
 				#used to showcase the player that those guys would die in case of a purge  - Fantom
 				NOT = {
@@ -4480,18 +4503,25 @@ characters = {
 				OR = {
 					SOV_is_left_opposition = yes
 					has_completed_focus = SOV_return_democracy_to_the_party
+					has_completed_focus = SOV_form_a_fifth_column_old
 				}
 				if = {
 					limit = {
 						has_character_flag = SOV_imprisoned_flag
 					}
-					NOT = { has_character_flag = SOV_imprisoned_flag } #For flavor purposes only -> Removed in the appropriate focus/event/dec
+					OR = {
+						has_completed_focus = SOV_form_a_fifth_column_old
+					NOT = 	{has_character_flag = SOV_imprisoned_flag}
+					} #For flavor purposes only -> Removed in the appropriate focus/event/dec
 				}
 				if = {
 					limit = {
 						has_character_flag = SOV_exiled_flag
 					}
-					NOT = { has_character_flag = SOV_exiled_flag }
+					OR = {
+						has_completed_focus = SOV_form_a_fifth_column_old
+					NOT = 	{has_character_flag = SOV_exiled_flag}
+					}
 				}
 				#used to showcase the player that those guys would die in case of a purge  - Fantom
 				NOT = {
@@ -4610,7 +4640,7 @@ characters = {
 					limit = {
 						has_global_flag = sov_old_focus_tree
 					}
-					has_completed_focus =  SOV_trotskyite_victory
+					has_completed_focus =  SOV_form_a_fifth_column_old
 				}
 				else = {
 					OR = {
@@ -4674,6 +4704,7 @@ characters = {
 			}
 			available = {
 				OR = {
+					has_completed_focus = SOV_form_a_fifth_column_old
 					SOV_is_right_opposition = yes
 					has_completed_focus = SOV_return_democracy_to_the_party
 				}
@@ -4963,7 +4994,11 @@ characters = {
 					limit = {
 						has_global_flag = sov_old_focus_tree
 					}
+				OR = {
+
+					has_completed_focus = SOV_form_a_fifth_column_old
 					has_completed_focus = SOV_orthadox_resurgance
+			}
 				}
 				else = {
 					OR = {
@@ -5103,7 +5138,10 @@ characters = {
 					limit = {
 						has_character_flag = SOV_exiled_flag
 					}
-					NOT = { has_character_flag = SOV_exiled_flag }
+					OR = {
+						has_completed_focus = SOV_form_a_fifth_column_old
+					NOT = 	{has_character_flag = SOV_exiled_flag}
+					}
 				}
 			}
 			traits = {
@@ -5204,7 +5242,10 @@ characters = {
 					limit = {
 						has_character_flag = SOV_exiled_flag
 					}
-					NOT = { has_character_flag = SOV_exiled_flag }
+					OR = {
+						has_completed_focus = SOV_form_a_fifth_column_old
+					NOT = 	{has_character_flag = SOV_exiled_flag}
+					}
 				}
 			}
 			traits = {
@@ -5246,7 +5287,10 @@ characters = {
 					limit = {
 						has_character_flag = SOV_exiled_flag
 					}
-					NOT = { has_character_flag = SOV_exiled_flag }
+					OR = {
+						has_completed_focus = SOV_form_a_fifth_column_old
+					NOT = 	{has_character_flag = SOV_exiled_flag}
+					}
 				}
 			}
 			traits = {
@@ -5284,7 +5328,10 @@ characters = {
 					limit = {
 						has_character_flag = SOV_exiled_flag
 					}
-					NOT = { has_character_flag = SOV_exiled_flag }
+					OR = {
+						has_completed_focus = SOV_form_a_fifth_column_old
+					NOT = 	{has_character_flag = SOV_exiled_flag}
+					}
 				}
 			}
 			traits = {
@@ -5325,7 +5372,10 @@ characters = {
 					limit = {
 						has_character_flag = SOV_exiled_flag
 					}
-					NOT = { has_character_flag = SOV_exiled_flag }
+					OR = {
+						has_completed_focus = SOV_form_a_fifth_column_old
+					NOT = 	{has_character_flag = SOV_exiled_flag}
+					}
 				}
 				if = {
 					limit = {
@@ -5684,7 +5734,10 @@ characters = {
 						limit = {
 							has_character_flag = SOV_exiled_flag
 						}
-						NOT = { has_character_flag = SOV_exiled_flag }
+						OR = {
+							has_completed_focus = SOV_form_a_fifth_column_old
+						NOT = 	{has_character_flag = SOV_exiled_flag}
+						}
 					}
 				}
 				traits = {

--- a/common/national_focus/soviet_old.txt
+++ b/common/national_focus/soviet_old.txt
@@ -5441,6 +5441,9 @@ focus = {
 				SOV_konstantin_nechaev = {
 					clr_character_flag = SOV_exiled_flag
 				}
+				SOV_ivan_smirnov = {
+					clr_character_flag = SOV_imprisoned_flag
+				}
 			}
 			if = {
 				limit = {


### PR DESCRIPTION
the event for unexiling/prison for anti stalinist advisors werent unlocking in 56 tree so made them hard unlock when doing the focus that triggers the event without affecting the base game tree.