### PR TITLE
reworks for shock troopers, infantry equipment

### DIFF
--- a/common/units/equipment/anti_air.txt
+++ b/common/units/equipment/anti_air.txt
@@ -35,8 +35,8 @@ equipments = {
 		#Offensive Abilities
 		soft_attack = 3
 		hard_attack = 7
-		ap_attack = 25
-		air_attack = 19
+		ap_attack = 15
+		air_attack = 10
 
 		#Space taken in convoy
 		lend_lease_cost = 3
@@ -72,7 +72,7 @@ equipments = {
 
 		soft_attack = 3.5
 		hard_attack = 11
-		ap_attack = 60
+		ap_attack = 30
 		air_attack = 25
 
 		build_cost_ic = 5

--- a/common/units/equipment/infantry.txt
+++ b/common/units/equipment/infantry.txt
@@ -84,7 +84,7 @@ equipments = {
 		ap_attack = 4
 		air_attack = 0
 
-		build_cost_ic = 0.5
+		build_cost_ic = 1
 		is_convertable = yes
 	}
 
@@ -112,7 +112,7 @@ equipments = {
 		ap_attack = 5
 		air_attack = 0
 		
-		build_cost_ic = 0.58
+		build_cost_ic = 1.1
 		resources = {
 			steel = 3
 		}
@@ -144,7 +144,7 @@ equipments = {
 		ap_attack = 10
 		air_attack = 0
 		
-		reliability = 0.8
+		reliability = 1.2
 		build_cost_ic = 0.69
 		resources = {
 			steel = 4
@@ -180,7 +180,7 @@ equipments = {
 		air_attack = 0
 		
 		reliability = 0.85
-		build_cost_ic = 0.8
+		build_cost_ic = 1.3 
 		resources = {
 			steel = 5
 		}

--- a/common/units/infantry.txt
+++ b/common/units/infantry.txt
@@ -32,7 +32,7 @@ sub_units = {
 		defense = -0.205
 		max_strength = 25
 		max_organisation = 60
-		default_morale = 0.3
+		default_morale = 0.15
 		manpower = 1000
 
 		#Misc Abilities
@@ -409,6 +409,7 @@ sub_units = {
 		}
 
 	}
+
 	desertinfantry = {
 		sprite = infantry
 		map_icon_category = infantry
@@ -470,7 +471,7 @@ sub_units = {
 	shocktroop = {
 		sprite = infantry
 		map_icon_category = infantry
-		special_forces = yes
+		special_forces = no
 		active = no
 		priority = 601
 		
@@ -492,22 +493,27 @@ sub_units = {
 
 		group = infantry
 
+		#offensive abilities 
+		soft_attack = 0.05
+		hard_attack = 0.05
+		breakthrough = 0.2
+
 		#Misc Abilities
 		training_time = 150
 		suppression = 2
 		weight = 0.5
-		supply_consumption = 0.08
+		supply_consumption = 0.15
 	
 		need = {
-			infantry_equipment = 130
-			support_equipment = 2
+			infantry_equipment = 250
+			support_equipment = 10
 		}
 	}
 	
 	mot_shocktroop = {
 		sprite = motorized
 		map_icon_category = infantry
-		special_forces = yes
+		special_forces = no
 		
 		
 		priority = 601
@@ -557,7 +563,7 @@ sub_units = {
 		need = {
 			infantry_equipment = 150
 			motorized_equipment = 50
-			support_equipment = 4
+			support_equipment = 5
 		}
 
 		urban = {
@@ -598,11 +604,10 @@ sub_units = {
 		}
 	}
 	
-	
 	mech_shocktroop = {
 		sprite = mechanized
 		map_icon_category = infantry
-		special_forces = yes
+		special_forces = no
 
 		priority = 610
 		ai_priority = 200
@@ -625,22 +630,22 @@ sub_units = {
 
 		#Offensive Abilities
 		defense = -0.205
-		soft_attack = 0.1
-		hard_attack = 4.0
+		soft_attack = 0.2
+		hard_attack = 6.0
 		breakthrough = 0.4
 		
 		#Size Definitions
 		max_strength = 30
 		max_organisation = 60
 		default_morale = 0.3
-		manpower = 1200
+		manpower = 1500
 
 		#Misc Abilities
 		training_time = 120
 		suppression = 2
 		weight = 1
 		
-		supply_consumption = 0.14
+		supply_consumption = 0.17
 		
 		# needed since we give so much bonus to infantry even with no mech equipment
 		essential = {
@@ -652,9 +657,9 @@ sub_units = {
 		transport = mechanized_equipment
 
 		need = {
-			mechanized_equipment = 50
-			infantry_equipment = 150
-			support_equipment = 4
+			mechanized_equipment = 75
+			infantry_equipment = 250
+			support_equipment = 10
 		}
 
 		forest = {
@@ -711,7 +716,7 @@ sub_units = {
 		defense = -0.205
 		max_strength = 30
 		max_organisation = 60
-		default_morale = 0.30
+		default_morale = 0.20
 		manpower = 1200
 
 		#Misc Abilities
@@ -836,7 +841,6 @@ sub_units = {
 
 		#hardness = 0.2 moving these buffs to unit stats
 	}
-	
 	
 	fake_intel_unit = {
 		sprite = infantry
@@ -989,6 +993,53 @@ sub_units = {
 			infantry_equipment = 80 # was 100 
 		}
 	}
+
+	militia = {
+		abbreviation = "MIL"
+		sprite = infantry
+		map_icon_category = infantry
+		
+		priority = 400
+		ai_priority = 150
+		active = no
+
+		type = {
+			infantry
+		}
+		
+		group = infantry
+		
+		categories = {
+			category_front_line
+			category_light_infantry
+			category_all_infantry
+			category_army
+			category_militia
+		}
+		
+		combat_width = 2
+		
+		#Size Definitions
+		defense = -0.205
+		max_strength = 25
+		max_organisation = 50 #reg infantry 60
+		default_morale = 0.3
+		manpower = 1000
+
+		#Misc Abilities
+		training_time = 80 #reg infantry 90
+		suppression = 1.5
+		weight = 0.5
+		
+		supply_consumption = 0.06
+	
+		need = {
+			infantry_equipment = 100
+		}
+	}
+
+}
+
 #	militia = { #R56 MILITIA KEPT AS REFERENCE UNTIL WE DEFINE BALANCE.
 #		sprite = infantry
 #		map_icon_category = infantry
@@ -1063,48 +1114,3 @@ sub_units = {
 #			infantry_equipment = 20
 #		}
 #	}
-	militia = {
-		abbreviation = "MIL"
-		sprite = infantry
-		map_icon_category = infantry
-		
-		priority = 400
-		ai_priority = 150
-		active = no
-
-		type = {
-			infantry
-		}
-		
-		group = infantry
-		
-		categories = {
-			category_front_line
-			category_light_infantry
-			category_all_infantry
-			category_army
-			category_militia
-		}
-		
-		combat_width = 2
-		
-		#Size Definitions
-		defense = -0.205
-		max_strength = 25
-		max_organisation = 50 #reg infantry 60
-		default_morale = 0.3
-		manpower = 1000
-
-		#Misc Abilities
-		training_time = 80 #reg infantry 90
-		suppression = 1.5
-		weight = 0.5
-		
-		supply_consumption = 0.06
-	
-		need = {
-			infantry_equipment = 100
-		}
-	}
-
-}


### PR DESCRIPTION
Shocktroopers are no longer special forces.

Shocktroop mechanized reworked:
increased hard attack (by 2.0)
increased soft attack (by 0.1)
increased supply consumption (by 0.03)

increased mechanized cost (by 25)
increased support equipment cost (by 6)
increased infantry equipment (by 100)
increased manpower cost (by 200)

Shocktroopers (infantry) reworked:
increased support equipment cost (by 6)
increased infantry equipment (by 100)
increased supply consumption (by 0.05)
increased hard attack (by 0.05)
increased soft attack (by 0.05)
increased breakthrough (by 0.2)

Infatry reworked:
reduced the recovery rate by 50%
reduced the recovery rate for motorized 30%
Increased infantry equipment IC cost by ( was .5 now is 1 )

Anti air reworked:
Reduced the air attack (by about 45% for anti-air 1) Reduced the piercing (by about 40% for anti-air 1 and 2)