### PR TITLE
TCDTF Small Changes 

### DIFF
--- a/common/characters/CHL.txt
+++ b/common/characters/CHL.txt
@@ -613,7 +613,7 @@ characters={
 			}  
 			cost = 100
 			traits = { 
-				navy_naval_air_defense_2
+				navy_screen_3
 			}
 			ai_will_do = {
 				factor = 1

--- a/common/decisions/HUN.txt
+++ b/common/decisions/HUN.txt
@@ -513,6 +513,90 @@ aftermath_of_the_munich_agreement = {
 }
 
 HUN_gyor_program_decision_category = {
+	HUN_open_new_factories = {
+        icon = GFX_decision_generic_merge_plant_tank
+        
+        fire_only_once = yes
+        
+        days_remove = 90
+        
+        cost = 50
+        
+        visible = {
+            has_completed_focus = HUN_domestic_arms_industry
+        }
+        
+        available = {
+            has_idea = HUN_idea_support_armament_manufacturers
+        }
+        
+        complete_effect = {
+        }
+        modifier = {
+            civilian_factory_use = 1
+        }
+        
+        remove_effect = {
+            random_owned_controlled_state = {
+                limit = {
+                    free_building_slots = {
+                        building = arms_factory
+                        size > 1
+                        include_locked = yes
+                    }
+                }
+                add_extra_state_shared_building_slots = 1
+                add_building_construction = {
+                    type = arms_factory
+                    level = 1
+                    instant_build = yes
+                }
+            }
+        }
+    }
+	HUN_invest_in_agriculture = {
+    
+        icon = generic_factory
+        
+        fire_only_once = yes
+        
+        days_remove = 180
+
+        cost = 50
+
+        visible = {
+        }
+        
+        available = {
+            has_idea = HUN_idea_support_armament_manufacturers
+            
+        }
+        
+        complete_effect = {
+            
+        }
+        modifier = {
+            civilian_factory_use = 1
+        }
+        remove_effect = {
+            
+            random_owned_controlled_state = {
+                limit = {
+                    free_building_slots = {
+                        building = industrial_complex
+                        size > 1
+                        include_locked = yes
+                    }
+                }
+                add_extra_state_shared_building_slots = 1
+                add_building_construction = {
+                    type = industrial_complex
+                    level = 1
+                    instant_build = yes
+                }
+            }
+        }
+    }
 	HUN_support_manufacturers_coordination = {
 		
 		icon = generic_factory

--- a/common/decisions/NaW_NOR_decisions.txt
+++ b/common/decisions/NaW_NOR_decisions.txt
@@ -1973,7 +1973,7 @@ NOR_railroad_development = {
 		}
 		
 		modifier = {
-			civilian_factory_use = 3
+			civilian_factory_use = 1
 		}
 		
 		remove_effect = {
@@ -2095,7 +2095,7 @@ NOR_railroad_development = {
 		}
 		
 		modifier = {
-			civilian_factory_use = 3
+			civilian_factory_use = 1
 		}
 		
 		remove_effect = {

--- a/common/decisions/formNation.txt
+++ b/common/decisions/formNation.txt
@@ -5630,10 +5630,7 @@ formable_nations_mod_category = {
 				limit = {
 					original_tag = PAK
 				}
-				add_ideas = RAJ_Caste_Debuff_1
-				add_ideas = generic_recent_army_unification
-				add_ideas = generic_recent_economic_unification
-				add_ideas = generic_recent_political_unification
+				
 			}
 			else = {
 				

--- a/common/decisions/formable_nation_decisions.txt
+++ b/common/decisions/formable_nation_decisions.txt
@@ -150,6 +150,7 @@ form_scandinavia_category = {
 			hidden_effect = {
 				news_event = { id = wtt_news.53 hours = 6 }
 				set_global_flag = form_scandinavia_flag
+				
 			}		
 		}
 

--- a/common/ideas/argentina.txt
+++ b/common/ideas/argentina.txt
@@ -42,7 +42,7 @@ ideas = {
 		
 			modifier = { 
 				MONTHLY_POPULATION = 1.25
-				consumer_goods_factor = 0.03
+				consumer_goods_factor = 0.02
 			}
 		}
 		
@@ -450,7 +450,7 @@ ideas = {
 			picture = generic_goods_red_bonus
 			
 			modifier = {
-				production_speed_industrial_complex_factor = 0.1
+				production_speed_industrial_complex_factor = 0.05
 				production_speed_infrastructure_factor = 0.1
 			}
 		}

--- a/common/ideas/belgium.txt
+++ b/common/ideas/belgium.txt
@@ -86,10 +86,11 @@ ideas = {
 			picture = tblra_van_den_bergen_plan
 			
 			modifier = {
-				production_factory_max_efficiency_factor = -0.05
+				industrial_capacity_factory = -0.05
 				production_speed_buildings_factor = -0.05 
 				political_power_factor = -0.05 
 				mobilization_speed = 0.25 
+				conscription_factor = 0.10
 				conscription = 0.01
 				
 			}
@@ -207,6 +208,20 @@ ideas = {
 			}
 
 			removal_cost = -1
+		}
+		tblra_Economic_Boom_of_Antwerp = {
+			allowed = {
+				always = no
+			}
+
+			modifier = {
+				local_resources_factor = 0.10
+				production_speed_buildings_factor = 0.10
+				consumer_goods_factor = -0.05
+			}
+
+			removal_cost = -1
+			picture = generic_
 		}		
 		tblra_leopold3_exile = {
 			
@@ -1447,12 +1462,12 @@ ideas = {
 				}				
 			}			
 			
-		#	equipment_bonus = {
-		#		artillery_equipment = {
-		#			max_speed = 0.10
-		#			instant = yes
-		#		}				
-		#	}
+			equipment_bonus = {
+				artillery_equipment = {
+					max_speed = 0.10
+					instant = yes
+				}				
+			}
 			
 			ai_will_do = {
 				factor = 0.66

--- a/common/ideas/brazil.txt
+++ b/common/ideas/brazil.txt
@@ -91,7 +91,7 @@ ideas = {
 			picture = generic_research_bonus
 			
 			modifier = {
-			research_speed_factor = 0.02
+			research_speed_factor = 0.03
 			}
 		}
 		
@@ -452,6 +452,7 @@ ideas = {
 			picture = BRA_ind_pic
 			
 			modifier = {
+				
 				production_factory_efficiency_gain_factor = 0.05
 				production_speed_infrastructure_factor = 0.05
 			}
@@ -1389,12 +1390,12 @@ ideas = {
 				subjects_autonomy_gain = -0.2
 				opinion_gain_monthly_same_ideology_factor = -0.1
 				communism_drift = 0.10
-				stability_factor = 0.05
+				stability_factor = 0.1
 				max_command_power = 25
 				political_power_factor = 0.25
-				conscription = 0.05
+				conscription = 0.02
 				training_time_factor = -0.05
-				army_org = 7
+				army_org = 5
 			}
 		}
 		

--- a/common/ideas/britain.txt
+++ b/common/ideas/britain.txt
@@ -1806,8 +1806,8 @@ ideas = {
 			}
 			
 			modifier = {
-				industrial_capacity_factory = 0.03
-				industrial_capacity_dockyard = 0.03
+				industrial_capacity_factory = 0.02
+				industrial_capacity_dockyard = 0.02
 			}
 
 			picture = generic_war_preparation
@@ -1816,6 +1816,28 @@ ideas = {
 		}
 
 		ENG_imperial_conference_defense_2 = {
+
+			name = ENG_imperial_conference_defense_dominion
+
+			allowed = {
+				always = no
+			}
+
+			allowed_civil_war = {
+				always = yes
+			}
+			
+			modifier = {
+				industrial_capacity_factory = 0.04
+				industrial_capacity_dockyard = 0.04
+			}
+
+			picture = generic_war_preparation
+
+			removal_cost = -1
+		}
+
+		ENG_imperial_conference_defense_3 = {
 
 			name = ENG_imperial_conference_defense_dominion
 
@@ -1837,28 +1859,6 @@ ideas = {
 			removal_cost = -1
 		}
 
-		ENG_imperial_conference_defense_3 = {
-
-			name = ENG_imperial_conference_defense_dominion
-
-			allowed = {
-				always = no
-			}
-
-			allowed_civil_war = {
-				always = yes
-			}
-			
-			modifier = {
-				industrial_capacity_factory = 0.09
-				industrial_capacity_dockyard = 0.09
-			}
-
-			picture = generic_war_preparation
-
-			removal_cost = -1
-		}
-
 		ENG_imperial_conference_defense_4 = {
 
 			name = ENG_imperial_conference_defense_dominion
@@ -1872,8 +1872,8 @@ ideas = {
 			}
 			
 			modifier = {
-				industrial_capacity_factory = 0.12
-				industrial_capacity_dockyard = 0.12
+				industrial_capacity_factory = 0.8
+				industrial_capacity_dockyard = 0.8
 			}
 
 			picture = generic_war_preparation
@@ -1894,8 +1894,8 @@ ideas = {
 			}
 			
 			modifier = {
-				industrial_capacity_factory = 0.15
-				industrial_capacity_dockyard = 0.15
+				industrial_capacity_factory = 0.1
+				industrial_capacity_dockyard = 0.1
 			}
 
 			picture = generic_war_preparation
@@ -1937,9 +1937,9 @@ ideas = {
 			}
 			
 			modifier = {
-				production_speed_industrial_complex_factor = 0.03
-				production_speed_arms_factory_factor = 0.03
-				production_speed_dockyard_factor = 0.03
+				production_speed_industrial_complex_factor = 0.02
+				production_speed_arms_factory_factor = 0.02
+				production_speed_dockyard_factor = 0.02
 			}
 
 			picture = generic_exploit_mines
@@ -1947,6 +1947,28 @@ ideas = {
 			removal_cost = -1
 		}
 		ENG_imperial_conference_economy_2 = {
+
+			name = ENG_imperial_conference_economy_dominion
+
+			allowed = {
+				always = no
+			}
+
+			allowed_civil_war = {
+				always = yes
+			}
+			
+			modifier = {
+				production_speed_industrial_complex_factor = 0.04
+				production_speed_arms_factory_factor = 0.04
+				production_speed_dockyard_factor = 0.04
+			}
+
+			picture = generic_exploit_mines
+
+			removal_cost = -1
+		}
+		ENG_imperial_conference_economy_3 = {
 
 			name = ENG_imperial_conference_economy_dominion
 
@@ -1968,28 +1990,6 @@ ideas = {
 
 			removal_cost = -1
 		}
-		ENG_imperial_conference_economy_3 = {
-
-			name = ENG_imperial_conference_economy_dominion
-
-			allowed = {
-				always = no
-			}
-
-			allowed_civil_war = {
-				always = yes
-			}
-			
-			modifier = {
-				production_speed_industrial_complex_factor = 0.09
-				production_speed_arms_factory_factor = 0.09
-				production_speed_dockyard_factor = 0.09
-			}
-
-			picture = generic_exploit_mines
-
-			removal_cost = -1
-		}
 		ENG_imperial_conference_economy_4 = {
 
 			name = ENG_imperial_conference_economy_dominion
@@ -2003,9 +2003,9 @@ ideas = {
 			}
 			
 			modifier = {
-				production_speed_industrial_complex_factor = 0.12
-				production_speed_arms_factory_factor = 0.12
-				production_speed_dockyard_factor = 0.12
+				production_speed_industrial_complex_factor = 0.8
+				production_speed_arms_factory_factor = 0.8
+				production_speed_dockyard_factor = 0.8
 			}
 
 			picture = generic_exploit_mines
@@ -2026,9 +2026,9 @@ ideas = {
 			}
 			
 			modifier = {
-				production_speed_industrial_complex_factor = 0.15
-				production_speed_arms_factory_factor = 0.15
-				production_speed_dockyard_factor = 0.15
+				production_speed_industrial_complex_factor = 0.1
+				production_speed_arms_factory_factor = 0.1
+				production_speed_dockyard_factor = 0.1
 			}
 
 			picture = generic_exploit_mines

--- a/common/ideas/bulgaria.txt
+++ b/common/ideas/bulgaria.txt
@@ -571,7 +571,8 @@ ideas = {
 			removal_cost = -1
 			
 			modifier = {
-				production_speed_industrial_complex_factor = 0.05		
+				production_speed_industrial_complex_factor = 0.05
+				consumer_goods_factor = -0.01		
 			}
 		}
 
@@ -591,7 +592,7 @@ ideas = {
 				production_speed_buildings_factor = 0.05
 				production_factory_efficiency_gain_factor = 0.02
 				production_factory_max_efficiency_factor = 0.02
-				consumer_goods_factor = 0.04
+				consumer_goods_factor = -0.02
 			}
 		}
 
@@ -612,7 +613,7 @@ ideas = {
 				production_speed_buildings_factor = 0.1
 				production_factory_efficiency_gain_factor = 0.05
 				production_factory_max_efficiency_factor = 0.05
-				consumer_goods_factor = 0.08
+				consumer_goods_factor = -0.03
 			}
 		}
 
@@ -634,7 +635,7 @@ ideas = {
 				production_factory_efficiency_gain_factor = 0.1
 				production_factory_max_efficiency_factor = 0.1
 				global_building_slots_factor = 0.2
-				consumer_goods_factor = -0.02
+				consumer_goods_factor = -0.05
 			}
 		}
 

--- a/common/ideas/canada.txt
+++ b/common/ideas/canada.txt
@@ -45,8 +45,8 @@ ideas = {
 			
 			modifier = {
 				consumer_goods_factor = -0.05
-				political_power_gain = 0.01
-				stability_factor = 0.05
+				political_power_gain = 0.15
+				stability_weekly = 0.001
 			}
 		}
 		CAN_canada_pacific_railway_idea = {
@@ -64,7 +64,7 @@ ideas = {
 			picture = generic_build_infrastructure
 			
 			modifier = {
-				global_building_slots_factor = 0.05
+				global_building_slots_factor = 0.10
 			}
 		}
 		CAN_maritime_colonial_railway_idea = {
@@ -100,7 +100,7 @@ ideas = {
 			picture = man_five_year_plan_industry
 			
 			modifier = {
-				global_building_slots_factor = 0.05
+				global_building_slots_factor = 0.10
 				MONTHLY_POPULATION = 0.1
 			}
 		}

--- a/common/ideas/chile.txt
+++ b/common/ideas/chile.txt
@@ -982,7 +982,7 @@ ideas = {
 			
 			picture = generic_central_management
 		}
-
+		
 		CHL_agrarian_reform = {
 		
 			allowed = {
@@ -1004,4 +1004,37 @@ ideas = {
 		}
 		
 	}
+	naval_manufacturer = {
+
+        designer = yes
+
+        CHL_ASMAR_Shipyard = {
+            picture = generic_navy_bonus
+			name = "ASMAR Shipyard"
+            allowed = {
+                original_tag = CHL
+            }
+            visible = {
+				always = yes
+			}
+            available = {
+                has_completed_focus = CHL_expand_magallanes_valparasio
+            }
+
+            research_bonus = {
+                naval_equipment = 0.15
+            }
+
+            equipment_bonus = {
+
+            }
+
+            traits = { raiding_fleet_naval_manufacturer }
+
+            modifier = {
+                industrial_capacity_dockyard = 0.20
+
+            }
+        }
+    }
 }

--- a/common/ideas/colombia.txt
+++ b/common/ideas/colombia.txt
@@ -45,6 +45,25 @@ ideas = {
 				industrial_capacity_dockyard = 0.1
 			}
 		}
+		COL_Reforming_the_Education_System = {
+			
+			
+			allowed = {
+				always = no
+			}
+
+			allowed_civil_war = {
+				always = yes
+			}
+
+			removal_cost = -1
+
+			picture = generic_production_bonus
+			
+			modifier = {
+				research_speed_factor = 0.02
+			}
+		}
 		COL_continue_constitutional_reforms = {
 			
 			

--- a/common/ideas/colombia.txt
+++ b/common/ideas/colombia.txt
@@ -41,8 +41,8 @@ ideas = {
 			picture = generic_production_bonus
 			
 			modifier = {
-				industrial_capacity_factory = 0.08
-				industrial_capacity_dockyard = 0.08
+				industrial_capacity_factory = 0.1
+				industrial_capacity_dockyard = 0.1
 			}
 		}
 		COL_continue_constitutional_reforms = {
@@ -246,7 +246,7 @@ ideas = {
 
 			equipment_bonus = {
 				submarine = {
-					build_cost_ic = -0.05 instant = yes
+					build_cost_ic = -0.10 instant = yes
 				}
 			}
 		}

--- a/common/ideas/denmark.txt
+++ b/common/ideas/denmark.txt
@@ -820,9 +820,9 @@ ideas = {
 			removal_cost = -1
 			picture = ger_the_great_red_menace
 			modifier = {
-				consumer_goods_factor = -0.02
-				production_factory_efficiency_gain_factor = 0.03
-				trade_opinion_factor = 0.1
+				consumer_goods_factor = -0.05
+				production_factory_efficiency_gain_factor = 0.05
+				trade_opinion_factor = 0.15
 			}
 		}
 		den_baltic_trade = {

--- a/common/ideas/egypt.txt
+++ b/common/ideas/egypt.txt
@@ -66,6 +66,24 @@ ideas = {
 				custom_modifier_tooltip = BHU_can_decline_effect
 			}
 		}
+		EGY_British_Acceptance = {
+			name = "British Acceptance"
+			picture = eng_chiefs_of_staff_committee
+			allowed = {
+				
+			}	
+			
+			
+			
+			
+			modifier = {
+				stability_weekly = 0.001
+				global_building_slots_factor = 0.10
+				political_power_factor = -0.05
+				production_speed_bunker_factor = 0.25
+				production_speed_coastal_bunker_factor = 0.25
+			}
+		}
 		EGY_promote_agricultural_development_idea = {
 			picture = generic_agrarian_reform
 			allowed = {
@@ -73,8 +91,8 @@ ideas = {
 			}			
 			
 			modifier = {
-				global_building_slots_factor = 0.1
-				industrial_capacity_factory = 0.05
+				global_building_slots_factor = 0.05
+				industrial_capacity_factory = 0.1
 				production_speed_buildings_factor = 0.1
 			}
 		}

--- a/common/ideas/estonia.txt
+++ b/common/ideas/estonia.txt
@@ -416,7 +416,7 @@ ideas = {
 			removal_cost = -1
 			
 			modifier = {
-				consumer_goods_factor = -0.03
+				consumer_goods_factor = -0.05
 			}
 		}
 
@@ -455,7 +455,7 @@ ideas = {
 			removal_cost = -1
 			
 			modifier = {
-				consumer_goods_factor = -0.02
+				
 				global_building_slots_factor = 0.2
 			}
 		}

--- a/common/ideas/finances.txt
+++ b/common/ideas/finances.txt
@@ -14,6 +14,7 @@ ideas = {
 				consumer_goods_factor = -0.02
 				political_power_factor = -0.15
 				production_speed_arms_factory_factor = 0.1
+				production_speed_dockyard_factor = 0.1
 				production_speed_industrial_complex_factor = -0.1
 				production_speed_bunker_factor = 0.1
 				production_speed_coastal_bunker_factor = 0.1

--- a/common/ideas/finland.txt
+++ b/common/ideas/finland.txt
@@ -132,7 +132,7 @@ ideas = {
 	
 			modifier = {
 				conscription = 0.05
-				mobilization_speed = 0.05
+				mobilization_speed = 0.25
 			}
 		}
 	
@@ -207,7 +207,7 @@ ideas = {
 
 			equipment_bonus = {
 				infantry_equipment = {
-					build_cost_ic = -0.1 instant = yes
+					build_cost_ic = -0.15 instant = yes
 				}
 			}
 		}
@@ -230,7 +230,44 @@ ideas = {
 				send_volunteers_tension = -0.5
 			}
 		}
-		
+		fin_Finnish_Swedish_Defense_Pact = {
+			allowed = {
+				always = no
+			}
+
+			allowed_civil_war = {
+				always = yes
+			}
+			
+			removal_cost = -1
+			
+			picture = generic_volunteer_expedition_bonus
+
+			modifier = {
+
+				conscription = 0.01
+				conscription_factor = 0.15
+				research_speed_factor = 0.05
+			}
+		}
+		fin_Finnish_Swedish_Industrial_Pact = {
+			allowed = {
+				always = no
+			}
+
+			allowed_civil_war = {
+				always = yes
+			}
+			
+			removal_cost = -1
+			
+			picture = generic_volunteer_expedition_bonus
+
+			modifier = {
+				local_building_slots_factor = 0.10
+				
+			}
+		}
 		fin_revenge = {
 			allowed = {
 				always = no
@@ -449,10 +486,9 @@ ideas = {
 			
 			picture = generic_morale_bonus
 			modifier = {
-				stability_factor = 0.05
-				political_power_gain = 0.15
-				consumer_goods_factor = -0.02
-				war_support_factor = -0.075
+				stability_factor = -0.10
+				political_power_cost = 0.15
+				
 			}
 		}
 		

--- a/common/ideas/greece.txt
+++ b/common/ideas/greece.txt
@@ -384,7 +384,7 @@ ideas = {
 				
 			modifier = {
 				conscription_factor = 0.1	
-				war_support_factor = 0.05		
+				war_support_factor = 0.10		
 			}
 		}	
 

--- a/common/ideas/hungary.txt
+++ b/common/ideas/hungary.txt
@@ -260,6 +260,7 @@ ideas = {
 			}
 			
 			modifier = {
+				research_speed_factor = 0.10
 				production_speed_infrastructure_factor = 0.1
 				production_speed_industrial_complex_factor = 0.1
 			}
@@ -439,6 +440,7 @@ ideas = {
 				always = yes			
 			}
 			modifier = {
+				local_building_slots_factor = 0.10
 				tank_manufacturer_cost_factor = -0.50
 				aircraft_manufacturer_cost_factor = -0.50
 				materiel_manufacturer_cost_factor = -0.50

--- a/common/ideas/norway.txt
+++ b/common/ideas/norway.txt
@@ -470,7 +470,7 @@ ideas = {
 			picture = escort_effort_focus
 			
 			modifier = {
-				consumer_goods_factor = -0.03
+				consumer_goods_factor = -0.05
 			}
 		}
 		
@@ -499,7 +499,7 @@ ideas = {
 			picture = liberty_ships_focus
 			
 			modifier = {
-				consumer_goods_factor = -0.03
+				consumer_goods_factor = -0.05
 				industrial_capacity_dockyard = 0.25
 			}
 			
@@ -580,14 +580,14 @@ ideas = {
 				}
 				capital_ship = {
 					anti_air_attack = 0.05
-					naval_speed = 0.05
-					surface_visibility = -0.05
+					naval_speed = 0.10
+					surface_visibility = -0.10
 					instant = yes
 				}
 				screen_ship = {
 					anti_air_attack = 0.05
-					naval_speed = 0.05
-					surface_visibility = -0.05
+					naval_speed = 0.10
+					surface_visibility = -0.10
 					instant = yes
 				}
 			}
@@ -849,9 +849,10 @@ ideas = {
 			
 			modifier = {
 				production_speed_buildings_factor = 0.05
-				industry_repair_factor = 0.05
+				global_building_slots_factor = 0.10
+				industry_repair_factor = 0.10
 				send_volunteers_tension = -0.50
-				send_volunteer_divisions_required = -0.50
+				send_volunteer_divisions_required = -1
 			}
 			
 			rule = { can_send_volunteers = yes }
@@ -875,14 +876,16 @@ ideas = {
 			picture = chi_wargaming_division
 			
 			modifier = {
+				production_speed_buildings_factor = 0.10
+				global_building_slots_factor = 0.20
 				conscription_factor = 0.10
 				army_core_defence_factor = 0.10
 				dig_in_speed_factor = 0.10
 				recon_factor_while_entrenched = 0.10
 				ai_focus_defense_factor = 0.10
-				industry_repair_factor = 0.10
-				send_volunteers_tension = -0.40
-				send_volunteer_divisions_required = -0.40
+				industry_repair_factor = 0.20
+				send_volunteers_tension = -0.50
+				send_volunteer_divisions_required = -1
 				resistance_damage_to_garrison = -0.20
 			}
 			

--- a/common/ideas/persia.txt
+++ b/common/ideas/persia.txt
@@ -419,6 +419,27 @@ ideas = {
 				custom_modifier_tooltip = MEX_oil_concessions_tt
 			}
 		}
+		PER_anglo_iranian_oil_company = {
+			picture = PER_anglo_iranian_oil_company
+			removal_cost = -1
+			
+			allowed = { always = no}
+			cancel = {
+				OR = {
+					is_subject = yes
+					is_puppet = yes
+					has_war_with = ENG
+				}	
+			}
+
+			modifier = {
+				industrial_capacity_factory = -0.05
+				min_export = 0.15
+				local_resources_factor = -0.2
+				custom_modifier_tooltip = MEX_oil_concessions_tt
+			}
+		}
+		
 	}
 	
 	materiel_manufacturer = {

--- a/common/ideas/r56_generic_tree.txt
+++ b/common/ideas/r56_generic_tree.txt
@@ -495,7 +495,7 @@ ideas = {
 			picture = generic_volunteer_expedition_bonus
 			
 			modifier = {
-				political_power_gain = 0.05
+				political_power_gain = 0.15
 			
 				send_volunteers_tension = -0.50
 				send_volunteer_divisions_required = -0.5

--- a/common/ideas/r56_soviet.txt
+++ b/common/ideas/r56_soviet.txt
@@ -678,7 +678,7 @@ ideas = {
 			modifier = {
 					consumer_goods_factor = 0.1
 					research_speed_factor = -0.1
-					conversion_cost_civ_to_mil_factor = -0.20
+					
 					production_factory_efficiency_gain_factor = -0.15
 					production_factory_max_efficiency_factor = 0.05
 					production_speed_arms_factory_factor = 0.1
@@ -779,7 +779,7 @@ ideas = {
 					production_factory_efficiency_gain_factor = -0.15
 					production_factory_max_efficiency_factor = 0.05
 					production_speed_industrial_complex_factor = 0.1
-					conversion_cost_mil_to_civ_factor = -0.20
+					
 					custom_modifier_tooltip = SOV_revolutionized_industry_tt
 			}
 		}

--- a/common/ideas/saudi_arabia.txt
+++ b/common/ideas/saudi_arabia.txt
@@ -404,8 +404,8 @@ country = {
 
 			modifier = {
 
-			army_infantry_attack_factor = 0.05
-			army_infantry_defence_factor = 0.05
+			army_infantry_attack_factor = 0.1
+			army_infantry_defence_factor = 0.1
 
 			}
 		}

--- a/common/ideas/scotland.txt
+++ b/common/ideas/scotland.txt
@@ -60,8 +60,8 @@ ideas = {
 			removal_cost = -1
 			
 			modifier = {
-				navy_chief_cost_factor = -0.5
-				naval_coordination = 0.07 
+				navy_chief_cost_factor = -0.25
+				naval_coordination = 0.10
 			}
 		}			
 	}

--- a/common/ideas/venezuela.txt
+++ b/common/ideas/venezuela.txt
@@ -424,6 +424,8 @@ ideas = {
 
 			modifier = {
 				attrition = -0.1
+				army_attack_factor = 0.1
+				army_defence_factor = 0.1
 			}
 		}
 		VEN_strikes_caracas = {
@@ -453,7 +455,7 @@ ideas = {
 
 				modifier = {
 					global_building_slots_factor = 0.2
-					consumer_goods_factor = -0.02
+					
 			}
 		}
 		VEN_labour_reforms = {
@@ -465,7 +467,7 @@ ideas = {
 				}
 
 				modifier = {
-					research_speed_factor = 0.02
+					research_speed_factor = 0.05
 					production_factory_efficiency_gain_factor = 0.1
 			}
 		}
@@ -501,6 +503,7 @@ ideas = {
 			modifier = {
 				production_speed_arms_factory_factor = 0.1
 				production_factory_start_efficiency_factor = 0.05
+				production_factory_max_efficiency_factor = 0.1
 			}
 		}
 		VEN_gran_colombian_ideals = {
@@ -517,7 +520,7 @@ ideas = {
 			picture = legitimize_gran_colombia
 
 			modifier = {
-				justify_war_goal_time = -0.1
+				justify_war_goal_time = -0.25
 				conscription = 0.01
 
 			}
@@ -535,7 +538,7 @@ ideas = {
 			picture = legitimize_gran_colombia
 
 			modifier = {
-				justify_war_goal_time = -0.25
+				justify_war_goal_time = -0.35
 				conscription = 0.015
 
 			}
@@ -758,7 +761,7 @@ ideas = {
 			picture = generic_agrarian_reform
 
 			modifier = {
-				consumer_goods_factor = -0.04
+				consumer_goods_factor = -0.05
 				industrial_capacity_factory = 0.05
 				industrial_capacity_dockyard = 0.05
 				trade_opinion_factor = -0.05
@@ -780,11 +783,11 @@ ideas = {
 			picture = generic_agrarian_reform
 
 			modifier = {
-				consumer_goods_factor = -0.08
-				industrial_capacity_factory = 0.05
-				industrial_capacity_dockyard = 0.05
+				consumer_goods_factor = -0.1
+				industrial_capacity_factory = 0.1
+				industrial_capacity_dockyard = 0.1
 				global_building_slots = 0.1
-				trade_opinion_factor = -0.05
+				trade_opinion_factor = -0.1
 
 			}
 		}

--- a/common/national_focus/Iraq.txt
+++ b/common/national_focus/Iraq.txt
@@ -12,6 +12,7 @@ focus_tree = {
 
 	default = no
 	shared_focus = SYR_UNIFIED_arab_unification
+	shared_focus = GEN_Industrial_Boom
 	continuous_focus_position = { x = 0 y = 1250 }
 
 	############################
@@ -530,7 +531,51 @@ focus_tree = {
 	 	}
 	 	search_filters = { FOCUS_FILTER_INDUSTRY FOCUS_FILTER_STEEL}
 	}
+	focus = {
+		id = IRQ_invest_in_steel
+		icon = GFX_focus_generic_industry_2
+		prerequisite = { focus = IRQ_finish_the_railyways focus = IRQ_labor_camps }
+		x = 1
+		y = 1
+		relative_position_id = IRQ_finish_the_railyways
+		cost = 10
+		ai_will_do = {
+			base = 10
+		}
 
+		completion_reward = {
+
+				random_owned_controlled_state = {
+
+					add_extra_state_shared_building_slots = 4
+					add_building_construction = {
+						type = industrial_complex
+						level = 2
+						instant_build = yes
+					}
+					add_building_construction = {
+						type = steel_mill
+						level = 2
+						instant_build = yes
+					}				
+					add_resource = {
+						type = steel
+						amount = 12
+					}			
+				}
+				modify_building_resources = {
+					building = steel_mill
+					resource = steel
+					amount = 2
+				}
+				add_tech_bonus = {
+					ahead_reduction = 2
+					uses = 2
+					bonus = 1
+					category = steel_tech	
+				}
+			}
+	}
 
 	focus = {
 		id = IRQ_establish_the_univeristy_of_baghdad

--- a/common/national_focus/Iraq.txt
+++ b/common/national_focus/Iraq.txt
@@ -49,7 +49,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = IRQ_arab_industrial_revolution
 		prerequisite = { focus = IRQ_arab_industrial_revolution }
-		cost = 10
+		cost = 8
 
 		ai_will_do = {
 			factor = 10
@@ -85,7 +85,7 @@ focus_tree = {
 		completion_reward = {
 			random_owned_controlled_state = {
 				prioritize = { 675 }			
-				add_extra_state_shared_building_slots = 3
+				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = infrastructure
 					level = 2
@@ -151,7 +151,7 @@ focus_tree = {
 		prerequisite = { focus = IRQ_modernisation_of_rural_villages }
 		x = 0
 		y = 2
-		cost = 5
+		cost = 10
 
 		ai_will_do = {
 			factor = 10
@@ -166,10 +166,10 @@ focus_tree = {
 			}
 			random_owned_controlled_state = {
 				prioritize = { 291 }
-				add_extra_state_shared_building_slots = 1
+				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = industrial_complex
-					level = 1
+					level = 2
 					instant_build = yes
 				}
 			}
@@ -292,7 +292,7 @@ focus_tree = {
 				}
 				add_building_construction = {
 					type = industrial_complex
-					level = 1
+					level = 2
 					instant_build = yes
 				}
 			}
@@ -310,7 +310,7 @@ focus_tree = {
 		prerequisite = { focus = IRQ_arab_industrial_revolution }
 		x = 5
 		y = 1
-		cost = 5
+		cost = 10
 
 		ai_will_do = {
 			factor = 5
@@ -329,7 +329,7 @@ focus_tree = {
 					instant_build = yes
 				}
 			}
-			add_stability = 0.05
+			add_stability = 0.15
 		}
 	search_filters = { FOCUS_FILTER_INDUSTRY }
 }
@@ -341,7 +341,7 @@ focus_tree = {
 		prerequisite = { focus = IRQ_ghazis_propaganda_station }
 		x = 4
 		y = 2
-		cost = 5
+		cost = 10
 
 		ai_will_do = {
 			factor = 10
@@ -350,7 +350,7 @@ focus_tree = {
 		completion_reward = {
 			random_owned_controlled_state = {
 				prioritize = { 10 }
-				add_extra_state_shared_building_slots = 2
+				add_extra_state_shared_building_slots = 3
 				add_building_construction = {
 					type = arms_factory
 					level = 2
@@ -417,7 +417,7 @@ focus_tree = {
 		 	}
 			add_resource = {
 				type = oil
-				amount = 8
+				amount = 10
 				state = 291
 			}
 		}
@@ -431,7 +431,7 @@ focus_tree = {
 		prerequisite = { focus = IRQ_expanded_oil_drilling }
 		x = 6
 		y = 3
-		cost = 5
+		cost = 10
 
 		ai_will_do = {
 			factor = 10
@@ -441,10 +441,10 @@ focus_tree = {
 		completion_reward = {
 			random_owned_controlled_state = {
 				prioritize = { 676 }
-				add_extra_state_shared_building_slots = 2
+				add_extra_state_shared_building_slots = 4
 				add_building_construction = {
 					type = arms_factory
-					level = 2
+					level = 1
 					instant_build = yes
 	  			}
 			}
@@ -477,7 +477,7 @@ focus_tree = {
 			}
 			random_owned_controlled_state = {
 				prioritize = { 675 }
-				add_extra_state_shared_building_slots = 1
+				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = arms_factory
 					level = 1
@@ -513,17 +513,17 @@ focus_tree = {
 					add_tech_bonus = {
 						name = construction_tech_bonus
 						bonus = 1
-						uses = 1
+						uses = 2
 						category = steel_tech
 					}					
 				}
 			}			
 			random_owned_controlled_state = {
 				prioritize = { 676 }
-				add_extra_state_shared_building_slots = 3
+				add_extra_state_shared_building_slots = 4
 				add_building_construction = {
 					type = steel_mill
-					level = 3
+					level = 4
 					instant_build = yes
 				}
 			}				
@@ -559,7 +559,7 @@ focus_tree = {
 		prerequisite = { focus = IRQ_establish_the_univeristy_of_baghdad }
 		x = 5
 		y = 6
-		cost = 5
+		cost = 10
 
 		ai_will_do = {
 			factor = 1
@@ -571,7 +571,7 @@ focus_tree = {
 			add_tech_bonus = {
 				name = IRQ_create_the_iraqi_block_cipher
 				bonus = 1
-				uses = 1
+				uses = 2
 				category = computing_tech
 			}
 		}
@@ -584,7 +584,7 @@ focus_tree = {
 		prerequisite = { focus = IRQ_establish_the_univeristy_of_baghdad }
 		x = 1
 		y = 6
-		cost = 5
+		cost = 8
 
 		ai_will_do = {
 			factor = 1
@@ -600,7 +600,7 @@ focus_tree = {
 				add_tech_bonus = {
 					name = codebreaking_bonus
 					bonus = 1.0
-					uses = 1
+					uses = 2
 					category = decryption_tech
 					category = computing_tech
 				}
@@ -647,7 +647,7 @@ focus_tree = {
 		prerequisite = { focus = IRQ_design_the_osirak_reactor }
 
 		available = {
-			num_of_factories > 50
+			num_of_factories > 30
 		}
 
 		available_if_capitulated = yes
@@ -686,10 +686,10 @@ focus_tree = {
 		available_if_capitulated = yes
 
 		completion_reward = {
-			army_experience = 10
+			army_experience = 25
 			add_doctrine_cost_reduction = {
 				name = IRQ_reform_the_army
-				cost_reduction = 0.5
+				cost_reduction = 1
 				uses = 2
 				category = land_doctrine
 			}
@@ -833,7 +833,7 @@ focus_tree = {
 		relative_position_id = IRQ_reform_the_army
 		x = -2
 		y = 1
-		cost = 5
+		cost = 10
 
 		ai_will_do = {
 			factor = 10
@@ -842,14 +842,14 @@ focus_tree = {
 		available_if_capitulated = yes
 
 		completion_reward = {
-			army_experience = 5
+			army_experience = 25
 			add_tech_bonus = {
 				name = IRQ_remove_dependency_on_british_equipment
 				bonus = 1
 				uses = 1
 				category = infantry_weapons
 			}
-			#1x 50% for Infantry Equipment
+			
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH }
 	}
@@ -876,7 +876,7 @@ focus_tree = {
 				uses = 1
 				category = motorized_equipment
 			}
-			#75% research bonus for Motorised
+			
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH }
 	}
@@ -888,7 +888,7 @@ focus_tree = {
 		relative_position_id = IRQ_motorized_army
 		x = -1
 		y = 1
-		cost = 5
+		cost = 10
 
 		ai_will_do = {
 			factor = 10
@@ -897,13 +897,14 @@ focus_tree = {
 		available_if_capitulated = yes
 
 		completion_reward = {
+			army_experience = 25
 			add_doctrine_cost_reduction = {
 				name = IRQ_study_new_land_doctrines
-				cost_reduction = 0.5
+				cost_reduction = 1
 				uses = 2
 				category = land_doctrine
 			}
-			#50% armor research
+			
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH }
 	}
@@ -1006,7 +1007,7 @@ focus_tree = {
 		available_if_capitulated = yes
 
 		completion_reward = {
-			army_experience = 15
+			army_experience = 25
 			add_tech_bonus = {
 				name = special_bonus
 				bonus = 1
@@ -1072,7 +1073,7 @@ focus_tree = {
 				category = infantry_weapons
 				category = support_tech
 			}
-			#1 x 50% for Infantry Equipment
+			
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH }
 	}
@@ -1093,14 +1094,14 @@ focus_tree = {
 		available_if_capitulated = yes
 
 		completion_reward = {
-			army_experience = 5
+			army_experience = 25
 			add_tech_bonus = {
 				name = IRQ_study_foreign_tanks
 				bonus = 1
 				uses = 1
 				category = armor
 			}
-			#50% armor research
+			
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH }
 	}
@@ -1179,7 +1180,7 @@ focus_tree = {
 				uses = 2
 				category = armor
 			}
-			#1x 50% reduction on research for medium tanks
+			
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH }
 	}
@@ -1195,7 +1196,7 @@ focus_tree = {
 
 		x = 15
 		y = 0
-		cost = 5
+		cost = 10
 
 		ai_will_do = {
 			factor = 1
@@ -1208,7 +1209,7 @@ focus_tree = {
 				limit = { has_state_flag = POL_Military_Aviation_Exports_1 }
 				add_building_construction = {
 					type = air_base
-					level = 2
+					level = 3
 					instant_build = yes
 				}
 			}
@@ -1224,7 +1225,7 @@ focus_tree = {
 				}
 				add_building_construction = {
 					type = air_base
-					level = 2
+					level = 3
 					instant_build = yes
 				}
 				set_state_flag = POL_Military_Aviation_Exports_1
@@ -1232,7 +1233,7 @@ focus_tree = {
 			#Add 2 Airbases in Warsaw
 			add_doctrine_cost_reduction = {
 				name = FRA_interwar_experience
-				cost_reduction = 0.5
+				cost_reduction = 1
 				uses = 1
 				category = air_doctrine
 			}

--- a/common/national_focus/afghanistan.txt
+++ b/common/national_focus/afghanistan.txt
@@ -649,4 +649,49 @@ focus_tree = {
 
         }
     }
+    focus = {
+		id = AFG_invest_in_steel
+		icon = GFX_focus_generic_steel
+		prerequisite = { focus = GEN_Excavation }
+		x = 33
+		y = 6
+		
+		cost = 10
+		ai_will_do = {
+			base = 10
+		}
+
+		completion_reward = {
+
+				random_owned_controlled_state = {
+
+					add_extra_state_shared_building_slots = 4
+					add_building_construction = {
+						type = industrial_complex
+						level = 2
+						instant_build = yes
+					}
+					add_building_construction = {
+						type = steel_mill
+						level = 2
+						instant_build = yes
+					}				
+					add_resource = {
+						type = steel
+						amount = 12
+					}			
+				}
+				modify_building_resources = {
+					building = steel_mill
+					resource = steel
+					amount = 2
+				}
+				add_tech_bonus = {
+					ahead_reduction = 2
+					uses = 2
+					bonus = 1
+					category = steel_tech	
+				}
+			}
+	}
 }

--- a/common/national_focus/argentina.txt
+++ b/common/national_focus/argentina.txt
@@ -31,12 +31,14 @@
 		}
 
 		completion_reward = {
+			add_political_power = 50
 			add_doctrine_cost_reduction = {
 				name = ARG_army_reform
-				cost_reduction = 0.6
-				uses = 1
+				cost_reduction = 1
+				uses = 2
 				category = land_doctrine
 			}
+			
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH }
 	}
@@ -48,7 +50,7 @@
 		mutually_exclusive = { focus = ARG_military_academy }
 		x = 4
 		y = 1
-		cost = 10
+		cost = 5
 		available = {
 			OR = {
 				ENG = {
@@ -88,9 +90,9 @@
 		mutually_exclusive = { focus = ARG_external_advisors }
 		x = 6
 		y = 1
-		cost = 10
+		cost = 5
 		completion_reward = {
-			army_experience = 10
+			army_experience = 50
 			add_doctrine_cost_reduction = {
 				name = ARG_military_academy
 				cost_reduction = 0.5
@@ -107,7 +109,7 @@
 		prerequisite = { focus = ARG_external_advisors focus = ARG_military_academy }
 		x = 2
 		y = 2
-		cost = 10
+		cost = 8
 		completion_reward = {
 			add_tech_bonus = {
 				name = ARG_motorized_army
@@ -125,13 +127,13 @@
 		prerequisite = { focus = ARG_motorized_army }
 		x = 1
 		y = 3
-		cost = 10
+		cost = 7
 		completion_reward = {
 			add_tech_bonus = {
-				name = ARG_study_foreign_tanks
+				name = ARG_tanks_modernization
 				bonus = 1
 				uses = 1
-				category = cat_light_armor
+				category = armor
 			}
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH }
@@ -143,11 +145,11 @@
 		prerequisite = { focus = ARG_motorized_army }
 		x = 3
 		y = 3
-		cost = 10
+		cost = 8
 		completion_reward = {
 			add_tech_bonus = {
 				name = ARG_mechanized_experiments
-				ahead_reduction = 0.5
+				ahead_reduction = 1
 				uses = 1
 				category = motorized_equipment
 			}
@@ -163,7 +165,7 @@
 		prerequisite = { focus = ARG_study_foreign_tanks }
 		x = 1
 		y = 4
-		cost = 10
+		cost = 7
 		completion_reward = {
 			add_tech_bonus = {
 				name = ARG_tanks_modernization
@@ -219,7 +221,7 @@
 		mutually_exclusive = { focus = ARG_heavy_tanks_experiments }
 		x = 0
 		y = 5
-		cost = 10
+		cost = 7
 		completion_reward = {
 			add_tech_bonus = {
 				name = ARG_cruiser_tanks_experiments
@@ -238,7 +240,7 @@
 		mutually_exclusive = { focus = ARG_cruiser_tanks_experiments }
 		x = 2
 		y = 5
-		cost = 10
+		cost = 7
 		completion_reward = {
 			add_tech_bonus = {
 				name = ARG_heavy_tanks_experiments
@@ -256,9 +258,9 @@
 		prerequisite = { focus = ARG_external_advisors focus = ARG_military_academy }
 		x = 5
 		y = 2
-		cost = 10
+		cost = 7
 		completion_reward = {
-			army_experience = 5
+			army_experience = 25
 			add_tech_bonus = {
 				name = ARG_study_foreign_equipment
 				bonus = 1
@@ -275,9 +277,9 @@
 		prerequisite = { focus = ARG_study_foreign_equipment }
 		x = 5
 		y = 3
-		cost = 10
+		cost = 7
 		completion_reward = {
-			army_experience = 5
+			army_experience = 25
 			add_tech_bonus = {
 				name = ARG_equipment_modernization
 				bonus = 1
@@ -307,9 +309,9 @@
 		prerequisite = { focus = ARG_equipment_modernization }
 		x = 6
 		y = 4
-		cost = 10
+		cost = 8
 		completion_reward = {
-			army_experience = 5
+			army_experience = 25
 			add_tech_bonus = {
 				name = ARG_equipment_innovation
 				bonus = 1
@@ -359,7 +361,7 @@
 		prerequisite = { focus = ARG_external_advisors focus = ARG_military_academy }
 		x = 8
 		y = 2
-		cost = 10
+		cost = 7
 		completion_reward = {
 			add_tech_bonus = {
 				name = ARG_artillery_modernization
@@ -417,7 +419,7 @@
 		prerequisite = { focus = ARG_new_officers_programme }
 		x = 10
 		y = 3
-		cost = 5
+		cost = 2
 		completion_reward = {
 			if = {
 				limit = { has_idea = neutrality_idea }
@@ -438,10 +440,11 @@
 		y = 0
 		cost = 5
 		completion_reward = {
+			add_political_power = 35
 			add_doctrine_cost_reduction = {
 				name = ARG_navy_reform
-				cost_reduction = 0.5
-				uses = 1
+				cost_reduction = 1
+				uses = 2
 				category = naval_doctrine
 			}
 		}
@@ -454,14 +457,14 @@
 		prerequisite = { focus = ARG_navy_reform }
 		x = 12
 		y = 1
-		cost = 10
+		cost = 5
 		
 		available = {
 			any_state = {
 				is_coastal = yes
 				is_controlled_by = ROOT
 			}
-			has_tech = construction1
+			
 		}
 		
 		completion_reward = {
@@ -569,14 +572,14 @@
 		prerequisite = { focus = ARG_state_dockyards }
 		x = 12
 		y = 2
-		cost = 10
+		cost = 5
 		
 		available = {
 			any_state = {
 				is_coastal = yes
 				is_controlled_by = ROOT
 			}
-			has_tech = construction2
+			
 		}
 		
 		completion_reward = {
@@ -684,7 +687,7 @@
 		prerequisite = { focus = ARG_navy_reform }
 		x = 14
 		y = 2
-		cost = 10
+		cost = 5
 		completion_reward = {
 			navy_experience = 50
 			add_ideas = arg_overseas_officers
@@ -698,7 +701,7 @@
 		prerequisite = { focus = ARG_overseas_officer_training }
 		x = 14
 		y = 3
-		cost = 10
+		cost = 5
 		
 		available = {
 			NOT = {
@@ -718,12 +721,12 @@
 		prerequisite = { focus = ARG_navy_reform }
 		x = 19
 		y = 1
-		cost = 10
+		cost = 5
 		completion_reward = {
 			add_doctrine_cost_reduction = {
 				name = ARG_fleet_modernization
-				cost_reduction = 0.5
-				uses = 1
+				cost_reduction = 1
+				uses = 2
 				category = naval_doctrine
 			}
 		}	
@@ -737,7 +740,7 @@
 		mutually_exclusive = { focus = ARG_submarines_modernization }
 		x = 16
 		y = 2
-		cost = 10
+		cost = 8
 		completion_reward = {
 			add_tech_bonus = {
 				name = ARG_screening_ships_modernization
@@ -773,7 +776,7 @@
 		prerequisite = { focus = ARG_screening_ships_modernization }
 		x = 16
 		y = 3
-		cost = 10
+		cost = 8
 		completion_reward = {
 			add_tech_bonus = {
 				name = ARG_cruisers_modernization
@@ -803,7 +806,7 @@
 		mutually_exclusive = { focus = ARG_screening_ships_modernization }
 		x = 18
 		y = 2
-		cost = 10
+		cost = 5
 		completion_reward = {
 			add_tech_bonus = {
 				name = ARG_submarines_modernization
@@ -832,7 +835,7 @@
 		prerequisite = { focus = ARG_submarines_modernization }
 		x = 18
 		y = 3
-		cost = 10
+		cost = 8
 		completion_reward = {
 			add_tech_bonus = {
 				name = ARG_submarines_experiments
@@ -864,7 +867,7 @@
 		mutually_exclusive = { focus = ARG_carrier_development }
 		x = 20
 		y = 2
-		cost = 10
+		cost = 8
 		completion_reward = {
 			add_tech_bonus = {
 				name = ARG_capital_ships_development
@@ -905,7 +908,7 @@
                 add_tech_bonus = {
                     name = SPR_navy_modernization
                     bonus = 1
-                    uses = 1
+                    uses = 2
                     category = naval_gunnery_tech
                     category = naval_shell_tech
                 }
@@ -921,7 +924,7 @@
 		mutually_exclusive = { focus = ARG_capital_ships_development }
 		x = 22
 		y = 2
-		cost = 10
+		cost = 5
 		completion_reward = {
 			add_tech_bonus = {
 				name = ARG_carrier_development
@@ -947,7 +950,7 @@
 		prerequisite = { focus = ARG_carrier_development }
 		x = 22
 		y = 3
-		cost = 10
+		cost = 5
 		completion_reward = {
 			add_tech_bonus = {
 				name = ARG_carrier_modernization
@@ -986,11 +989,11 @@
 		prerequisite = { focus = ARG_cruisers_modernization focus = ARG_submarines_experiments focus = ARG_capital_ships_modernization focus = ARG_carrier_modernization }
 		x = 19
 		y = 4
-		cost = 10
+		cost = 5
 		completion_reward = {
 			add_doctrine_cost_reduction = {
 				name = SPR_navy_modernization
-				cost_reduction = 0.5
+				cost_reduction = 1
 				uses = 2
 				category = naval_doctrine
 			}
@@ -1008,10 +1011,11 @@
 		y = 0
 		cost = 5
 		completion_reward = {
+			add_political_power = 35
 			add_doctrine_cost_reduction = {
 				name = ARG_air_force_reform
-				cost_reduction = 0.5
-				uses = 1
+				cost_reduction = 1
+				uses = 2
 				category = air_doctrine
 			}
 		}
@@ -1103,6 +1107,12 @@
 		y = 2
 		cost = 10
 		completion_reward = {
+			add_tech_bonus = {
+				name = ARG_air_force_reform
+				bonus = 1
+				uses = 2
+				category = air_equipment
+			}
 			air_experience = 50
 			add_ideas = arg_aviation_schools
 			add_doctrine_cost_reduction = {
@@ -1125,8 +1135,8 @@
 		completion_reward = {
 			add_doctrine_cost_reduction = {
 				name = ARG_air_innovations
-				cost_reduction = 0.5
-				uses = 1
+				cost_reduction = 1
+				uses = 2
 				category = air_doctrine
 			}
 			add_tech_bonus = {
@@ -1147,7 +1157,7 @@
 		prerequisite = { focus = ARG_aviation_schools }
 		x = 27
 		y = 3
-		cost = 10
+		cost = 5
 		completion_reward = {
 			random_owned_state = {
 				prioritize = {26 }			
@@ -1179,7 +1189,7 @@
 		completion_reward = {
 			add_doctrine_cost_reduction = {
 				name = ARG_air_doctrine
-				cost_reduction = 0.5
+				cost_reduction = 1
 				uses = 2
 				category = air_doctrine
 			}
@@ -1234,6 +1244,7 @@
 				}
 
 				completion_reward = {
+					add_political_power = 50
 						remove_ideas = arg_economic_depresion # A negative starting idea
 				}
 		}
@@ -1258,7 +1269,7 @@
 				prerequisite = { focus = ARG_end_of_economic_depresion }
 				x = 41
 				y = 1
-				cost = 10
+				cost = 7
 				
 				completion_reward = {
 					add_ideas = establish_the_bcra
@@ -1274,7 +1285,7 @@
 				cost = 5
 				
 				completion_reward = {
-					add_stability = 0.05
+					add_stability = 0.15
 					#add_ideas = law_11729 # More civilian consumption
 				}
 				search_filters = { FOCUS_FILTER_STABILITY }
@@ -1286,16 +1297,8 @@
 				prerequisite = { focus = ARG_law_11729 }
 				x = 39
 				y = 2
-				cost = 15
-				available = {
-					GER = {
-						OR = {
-							has_war_with = ENG
-							has_war_with = SOV
-							threat > 0.2
-						}
-					}
-				}
+				cost = 7
+				
 				
 				completion_reward = {
 					add_stability = -0.05
@@ -1329,7 +1332,7 @@
 				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = arms_factory
-					level = 2
+					level = 3
 					instant_build = yes
 				}
 			}
@@ -1358,10 +1361,10 @@
 							}
 						}
 					}
-					add_extra_state_shared_building_slots = 2
+					add_extra_state_shared_building_slots = 3
 					add_building_construction = {
 						type = arms_factory
-						level = 2
+						level = 3
 						instant_build = yes
 					}
 				}
@@ -1391,10 +1394,10 @@
 			}
 
 			complete_tooltip = {
-				add_extra_state_shared_building_slots = 2
+				add_extra_state_shared_building_slots = 3
 				add_building_construction = {
 					type = arms_factory
-					level = 2
+					level = 3
 					instant_build = yes
 				}
 			}
@@ -1423,10 +1426,10 @@
 							}
 						}
 					}
-					add_extra_state_shared_building_slots = 2
+					add_extra_state_shared_building_slots = 3
 					add_building_construction = {
 						type = arms_factory
-						level = 2
+						level = 3
 						instant_build = yes
 					}
 				}
@@ -1456,10 +1459,10 @@
 			}
 
 			complete_tooltip = {
-				add_extra_state_shared_building_slots = 2
+				add_extra_state_shared_building_slots = 3
 				add_building_construction = {
 					type = arms_factory
-					level = 2
+					level = 3
 					instant_build = yes
 				}
 			}
@@ -1488,10 +1491,10 @@
 							}
 						}
 					}
-					add_extra_state_shared_building_slots = 2
+					add_extra_state_shared_building_slots = 3
 					add_building_construction = {
 						type = arms_factory
-						level = 2
+						level = 3
 						instant_build = yes
 					}
 				}
@@ -1557,7 +1560,7 @@
 				prerequisite = { focus = ARG_end_of_economic_depresion }
 				x = 34
 				y = 1
-				cost = 10
+				cost = 5
 				
 				completion_reward = {
 					random_owned_state = {
@@ -1756,7 +1759,7 @@
 				prerequisite = { focus = ARG_imports_substitution }
 				x = 31
 				y = 3
-				cost = 10
+				cost = 5
 				
 				completion_reward = {
 					random_owned_state = {
@@ -1799,7 +1802,7 @@
 			prerequisite = { focus = ARG_industrial_development }
 			x = 31
 			y = 4
-			cost = 10
+			cost = 7
 			
 			completion_reward = {
 				random_owned_state = {
@@ -1842,7 +1845,7 @@
 			prerequisite = { focus = ARG_industrial_development_2 }
 			x = 31
 			y = 5
-			cost = 10
+			cost = 7
 			
 			completion_reward = {
 				random_owned_state = {
@@ -1929,7 +1932,7 @@
 				prerequisite = { focus = ARG_technological_initiative }
 				x = 35
 				y = 4
-				cost = 10
+				cost = 5
 				
 				completion_reward = {
 					add_tech_bonus = {
@@ -1955,7 +1958,7 @@
 				prerequisite = { focus = ARG_pioneers focus = ARG_nuclear_committe focus = ARG_proving_grounds }
 				x = 36
 				y = 5
-				cost = 10
+				cost = 7
 				
 				completion_reward = {
 					add_tech_bonus = {
@@ -2009,7 +2012,7 @@
 				}
 
 				available = {
-					num_of_factories > 50
+					num_of_factories > 40
 				}
 
 				completion_reward = {
@@ -2034,6 +2037,7 @@
 				}
 
 				completion_reward = {
+					add_political_power = 100
 					add_ideas = infamous_decade
 				}
 				search_filters = { FOCUS_FILTER_POLITICAL }
@@ -2072,7 +2076,7 @@
 				mutually_exclusive = { focus = ARG_nationalism }
 				x = 49
 				y = 2
-				cost = 10
+				cost = 5
 
 				ai_will_do = {
 					factor = 3
@@ -2080,7 +2084,7 @@
 
 				completion_reward = {
 					add_timed_idea = { idea = internationalism days = 1395 }
-					#add_stability = 0.10
+					add_stability = 0.10
 				}
 		}
 		
@@ -2091,7 +2095,7 @@
 			mutually_exclusive = { focus = ARG_land_of_the_worker }
 			x = 43
 			y = 2
-			cost = 7.2
+			cost = 5
 
 			ai_will_do = {
 				factor = 20
@@ -2102,7 +2106,7 @@
 					idea = nationalism
 					days = 1395
 				}
-				#add_stability = 0.10
+				add_stability = 0.10
 			}
 		}
 		focus = {
@@ -2112,14 +2116,14 @@
 			relative_position_id = ARG_nationalism
 			x = -3
 			y = 1
-			cost = 7.2
+			cost = 7
 
 			ai_will_do = {
 				factor = 20
 			}
 
 			completion_reward = {
-				add_political_power = 50
+				add_political_power = 75
 				custom_effect_tooltip = available_political_advisor
 				show_ideas_tooltip = ARG_julio_meinvielle
 			}
@@ -2192,7 +2196,7 @@
 			prerequisite = { focus = ARG_nationalism focus = ARG_land_of_the_worker }
 			x = 3
 			y = 1
-			cost = 5
+			cost = 2
 			ai_will_do = {
 				factor = 0.1
 				modifier = {
@@ -2235,7 +2239,7 @@
 
 				available = {
 					is_puppet = no
-					has_army_manpower = { size > 450000 } 	
+					
 					ENG = { owns_state = 299 }
 				}
 				
@@ -2248,7 +2252,7 @@
 				}
 			
 				completion_reward = {
-					add_stability = 0.05
+					add_stability = 0.10
 					add_named_threat = { threat = 1 name = ARG_malvinas_claim_threat }
 					ENG = {
 						add_opinion_modifier = { target = ARG modifier = demanded_falkland_islands }
@@ -2264,11 +2268,11 @@
 				prerequisite = { focus = ARG_malvinas_argentinas }
 				x = 43
 				y = 6
-				cost = 10
+				cost = 7
 
 				available = {
 					is_puppet = no
-					has_army_manpower = { size > 450000 } 		
+						
 					ENG = { owns_state = 720 }
 				}
 				
@@ -2281,7 +2285,7 @@
 				}
 
 				completion_reward = {
-					add_named_threat = { threat = 0.5 name = ARG_south_georgia_claim_threat }
+					add_named_threat = { threat = 1 name = ARG_south_georgia_claim_threat }
 					ENG = {
 						add_opinion_modifier = { target = ARG modifier = demanded_georgia_island }
 						country_event = argentina.18
@@ -2300,7 +2304,7 @@
 			
 				available = {
 					is_puppet = no
-					has_army_manpower = { size > 100000 } 		
+							
 				}
 				
 				bypass = {
@@ -2314,7 +2318,7 @@
 				
 				completion_reward = {
 					add_state_claim = 300
-					add_named_threat = { threat = 0.3 name = ARG_uruguay_claim_threat }
+					add_named_threat = { threat = 1 name = ARG_uruguay_claim_threat }
 					URG = {
 						add_opinion_modifier = { target = ARG modifier = arg_claim }
 					}
@@ -2334,7 +2338,7 @@
 				available = {
 					country_exists = URG
 					is_puppet = no
-					has_army_manpower = { size > 100000 } 		
+						
 				}
 				
 				bypass = {
@@ -2362,11 +2366,11 @@
 				prerequisite = { focus = ARG_uruguay_ocupation }
 				x = 42
 				y = 7
-				cost = 10
+				cost = 7
 				
 				available = {
 					is_puppet = no
-					has_army_manpower = { size > 150000 } 		
+							
 				}
 				
 				bypass = {
@@ -2379,7 +2383,7 @@
 				cancel_if_invalid = no
 								
 				completion_reward = {
-					add_named_threat = { threat = 0.3 name = ARG_paraguay_claim_threat }
+					add_named_threat = { threat = 1 name = ARG_paraguay_claim_threat }
 					add_state_claim = 301
 					add_state_claim = 688
 					create_wargoal = {
@@ -2401,11 +2405,11 @@
 				prerequisite = { focus = ARG_claim_paraguay }
 				x = 42
 				y = 8
-				cost = 10
+				cost = 7
 			
 				available = {
 					is_puppet = no
-					has_army_manpower = { size > 150000 } 		
+							
 				}
 				
 				bypass = {
@@ -2418,7 +2422,7 @@
 				cancel_if_invalid = no
 				
 				completion_reward = {
-					add_named_threat = { threat = 0.3 name = ARG_bolivia_claim_threat }
+					add_named_threat = { threat = 1 name = ARG_bolivia_claim_threat }
 					add_state_claim = 487
 					add_state_claim = 302
 					create_wargoal = {
@@ -2441,11 +2445,11 @@
 				prerequisite = { focus = ARG_uruguay_ocupation }
 				x = 40
 				y = 7
-				cost = 10
+				cost = 7
 				
 				available = {
 					is_puppet = no
-					has_army_manpower = { size > 150000 } 		
+							
 				}
 				
 				bypass = {
@@ -2462,7 +2466,7 @@
 				cancel_if_invalid = no
 								
 				completion_reward = {
-					add_named_threat = { threat = 0.3 name = ARG_chile_claim_threat }
+					add_named_threat = { threat = 1 name = ARG_chile_claim_threat }
 					add_state_claim = 279
 					add_state_claim = 506
 					add_state_claim = 507
@@ -2490,31 +2494,7 @@
 			y = 2
 			cost = 10
 			
-			available = {
-				is_puppet = no
-				has_army_manpower = { size > 200000 }
-				CHL = {
-					OR = {
-						is_puppet_of = ROOT
-						is_in_faction_with = ROOT
-						exists = no
-						num_of_controlled_states < 1
-					}
-				}
-				BOL = {
-					OR = {
-						is_puppet_of = ROOT
-						is_in_faction_with = ROOT
-						exists = no
-						num_of_controlled_states < 1
-					}
-				}
-				NOT = {
-					BRA = {
-						is_in_faction_with = ROOT	
-					}
-				}				 		
-			}
+			
 			
 			bypass = {
 				OR = {
@@ -2526,13 +2506,11 @@
 				
 			}
 			
-			cancel = {
-				has_war_with = BRA
-			}
+			
 			cancel_if_invalid = no
 							
 			completion_reward = {
-				add_named_threat = { threat = 0.3 name = ARG_brazil_puppet_threat }
+				add_named_threat = { threat = 1 name = ARG_brazil_puppet_threat }
 				create_wargoal = {
 					type = puppet_wargoal_focus
 					target = BRA
@@ -2628,7 +2606,7 @@
 
 			x = 42
 			y = 3
-			cost = 10
+			cost = 5
 			
 
 			
@@ -2820,7 +2798,7 @@
 			prerequisite = { focus = ARG_national_fanatism focus = ARG_join_the_axis }
 			x = 43
 			y = 4
-			cost = 10
+			cost = 5
 			
 			completion_reward = {
 				if = {
@@ -2828,7 +2806,7 @@
 					remove_ideas = neutrality_idea
 				}			
 				add_ideas = militarism_focus
-				army_experience = 20
+				army_experience = 50
 			}
 			search_filters = { FOCUS_FILTER_MILITARY_IMPROVEMENT FOCUS_FILTER_MANPOWER }
 		}		
@@ -2839,7 +2817,7 @@
 			prerequisite = { focus = ARG_national_fanatism }
 			x = 45
 			y = 4
-			cost = 10
+			cost = 8
 			
 			completion_reward = {
 				add_ideas = military_youth_focus
@@ -2867,7 +2845,7 @@
 			prerequisite = { focus = ARG_military_youth }
 			x = 45
 			y = 5
-			cost = 10
+			cost = 7
 			
 			completion_reward = {
 				add_ideas = paramilitarism_focus
@@ -2920,7 +2898,7 @@
 						limit = {
 							free_building_slots = {
 								building = industrial_complex
-								size > 2
+								size > 3
 								include_locked = yes
 							}
 							OR = {
@@ -2930,7 +2908,7 @@
 										any_owned_state = {
 											free_building_slots = {
 												building = industrial_complex
-												size > 2
+												size > 3
 												include_locked = yes
 											}
 											is_in_home_area = yes
@@ -2939,10 +2917,10 @@
 								}
 							}
 						}
-						add_extra_state_shared_building_slots = 2
+						add_extra_state_shared_building_slots = 3
 						add_building_construction = {
 							type = industrial_complex
-							level = 2
+							level = 3
 							instant_build = yes
 						}
 					}
@@ -2960,7 +2938,7 @@
 			prerequisite = { focus = ARG_land_of_the_worker }
 			x = 48
 			y = 3
-			cost = 7.2
+			cost = 5
 			
 			available = {
 				NOT = { has_war_with = SOV }
@@ -3002,8 +2980,8 @@
 						}
 						add_doctrine_cost_reduction = {
 							name = land_doc_bonus
-							cost_reduction = 0.5
-							uses = 1
+							cost_reduction = 1
+							uses = 2
 							category = cat_mass_assault
 						}
 					}					
@@ -3068,7 +3046,7 @@
 				}	
 				x = 0
 				y = 2
-				cost = 10
+				cost = 3
 				
 
 
@@ -3109,7 +3087,7 @@
 			prerequisite = { focus = ARG_land_of_the_worker }
 			x = 50
 			y = 3
-			cost = 10
+			cost = 5
 			
 			completion_reward = {
 				if = {
@@ -3129,7 +3107,7 @@
 			relative_position_id = ARG_political_correctness
 			x = 0
 			y = 1
-			cost = 10
+			cost = 8
 			
 			completion_reward = {
 				add_ideas = indoctrination_focus
@@ -3214,10 +3192,7 @@
 			allow_branch = {
 				has_dlc = "La Resistance"
 			}			
-			available = {
-				has_intelligence_agency = yes
-				agency_upgrade_number > 4
-			}
+			
 			relative_position_id = ARG_communist_secret_police
 			x = 0
 			y = 1
@@ -3239,7 +3214,7 @@
 			y = 1
 			relative_position_id = ARG_expand_the_intelligence_services
 	
-			cost = 5
+			cost = 3
 	
 			ai_will_do = {
 				factor = 0
@@ -3297,7 +3272,7 @@
 			y = 1
 			relative_position_id = ARG_political_commissars
 		
-			cost = 10
+			cost = 8
 		
 			ai_will_do = {
 				factor = 12
@@ -3328,7 +3303,7 @@
 			completion_reward = {
 				add_timed_idea = {
 					idea = SWE_workers_rallying
-					days = 98
+					days = 120
 				}
 			}
 		}				
@@ -3341,7 +3316,7 @@
 			relative_position_id = ARG_political_commissars
 			x = 0
 			y = 2
-			cost = 10
+			cost = 3
 			
 			available = {
 				is_puppet = no
@@ -3390,7 +3365,7 @@
 				}
 				is_puppet = no
 				surrender_progress  < 0.1
-				has_army_manpower = { size > 100000 } 		
+						
 			}
 			
 			bypass = {
@@ -3404,7 +3379,7 @@
 			
 			completion_reward = {
 				add_state_claim = 300
-				add_named_threat = { threat = 0.3 name = ARG_uruguay_claim_threat }
+				add_named_threat = { threat = 1 name = ARG_uruguay_claim_threat }
 				URG = {
 					add_opinion_modifier = { target = ARG modifier = arg_claim }
 					country_event = { id = argentina.3 }
@@ -3424,7 +3399,7 @@
 		
 		available = {
 			is_puppet = no
-			has_army_manpower = { size > 150000 } 		
+					
 			surrender_progress  < 0.1
 			NOT = {
 				PAR = {
@@ -3447,7 +3422,7 @@
 		cancel_if_invalid = no
 						
 		completion_reward = {
-			add_named_threat = { threat = 0.3 name = ARG_paraguay_claim_threat }
+			add_named_threat = { threat = 1 name = ARG_paraguay_claim_threat }
 			add_state_claim = 301
 			add_state_claim = 688
 			create_wargoal = {
@@ -3468,7 +3443,7 @@
 				prerequisite = { focus = ARG_one_mind }
 				x = 57
 				y = 3
-				cost = 7.2
+				cost = 5
 				
 				completion_reward = {
 					custom_effect_tooltip = ARG_south_americas_talks_tt
@@ -3593,7 +3568,7 @@
 			prerequisite = { focus = ARG_south_americas_talks }
 			x = 57
 			y = 4
-			cost = 7.2
+			cost = 5
 			
 			completion_reward = {
 				custom_effect_tooltip = ARG_anti_war_treaty_tt
@@ -3614,7 +3589,7 @@
 			prerequisite = { focus = ARG_anti_war_treaty }
 			x = 57
 			y = 5
-			cost = 7.2
+			cost = 5
 
 			completion_reward = {
 				custom_effect_tooltip = ARG_anti_war_treaty_2_tt
@@ -3634,7 +3609,7 @@
 			prerequisite = { focus = ARG_anti_war_treaty_2 }
 			x = 57
 			y = 6
-			cost = 7.2
+			cost = 5
 
 			completion_reward = {
 				custom_effect_tooltip = ARG_anti_war_treaty_3_tt
@@ -3658,7 +3633,7 @@
 			prerequisite = { focus = ARG_anti_war_treaty_3 }
 			x = 57
 			y = 7
-			cost = 20
+			cost = 8
 			available = {
 				is_in_faction = no
 			}
@@ -3859,7 +3834,7 @@
 				mutually_exclusive = { focus = ARG_liberty_focus }
 				x = 56
 				y = 2
-				cost = 7.2
+				cost = 5
 				ai_will_do = {
 					factor = 0.5
 					modifier = {
@@ -3870,7 +3845,7 @@
 								
 				completion_reward = {
 					#add_timed_idea = { idea = one_mind days = 300 }
-					add_stability = 0.05
+					add_stability = 0.10
 				}				
 				search_filters = { FOCUS_FILTER_STABILITY }
 		}
@@ -3882,7 +3857,7 @@
 				mutually_exclusive = { focus = ARG_one_mind }
 				x = 62
 				y = 2
-				cost = 7.2
+				cost = 7
 				ai_will_do = {
 					factor = 1
 					modifier = {
@@ -3910,7 +3885,7 @@
 				prerequisite = { focus = ARG_one_mind }
 				x = 55
 				y = 3
-				cost = 10
+				cost = 7
 								
 				completion_reward = {
 					add_manpower = 50000
@@ -4045,7 +4020,7 @@
 			prerequisite = { focus = ARG_brazil_non_agression }
 			x = 55
 			y = 6
-			cost = 7.2
+			cost = 7
 			
 			available = {
 					country_exists = BRA
@@ -4064,16 +4039,16 @@
 				army_experience = 50
 				add_doctrine_cost_reduction = {
 					name = ARG_brazil_joint_exercises
-					cost_reduction = 0.25
-					uses = 1
+					cost_reduction = 1
+					uses = 2
 					category = land_doctrine
 				}
 				BRA = {
-					army_experience = 50
+					army_experience = 100
 					add_doctrine_cost_reduction = {
 						name = ARG_brazil_joint_exercises
-						cost_reduction = 0.25
-						uses = 1
+						cost_reduction = 1
+						uses = 2
 						category = land_doctrine
 					}
 				}
@@ -4180,7 +4155,7 @@
 			relative_position_id = ARG_usa_coop
 			x = 1
 			y = 1
-			cost = 10
+			cost = 5
 			
 			available = {
 				is_puppet = no
@@ -4280,10 +4255,10 @@
 							}
 						}
 					}
-					add_extra_state_shared_building_slots = 2
+					add_extra_state_shared_building_slots = 3
 					add_building_construction = {
 						type = arms_factory
-						level = 1
+						level = 2
 						instant_build = yes
 					}
 					add_building_construction = {
@@ -4318,7 +4293,7 @@
 				add_tech_bonus = {
 					name = industrial_bonus
 					bonus = 1
-					uses = 1
+					uses = 2
 					category = excavation_tech
 				}			
 			}
@@ -4333,7 +4308,7 @@
 				relative_position_id = ARG_external_help_focus
 				x = 2
 				y = 1
-				cost = 7.2
+				cost = 5
 				
 				completion_reward = {
 					add_opinion_modifier = { target = ENG modifier = arg_coop }
@@ -4352,11 +4327,11 @@
 				y = 5
 				cost = 5
 				
-				completion_reward = {
-					#add_ideas = arg_usa_mil_coop
-					army_experience = 25
-					navy_experience = 25
-					air_experience = 25
+				completion_reward = {	
+					army_experience = 50
+					navy_experience = 50
+					air_experience = 50
+				
 				}
 		}
 		
@@ -4382,6 +4357,21 @@
 						uses = 1
 						category = naval_equipment
 					}
+				USA = {
+					add_tech_bonus = {
+						name = special_forces_bonus
+						bonus = 1
+						uses = 2
+						category = artillery
+						category = marine_tech
+					}
+					add_tech_bonus = {
+						name = NOR_naval_technology_bonus
+						bonus = 1
+						uses = 1
+						category = naval_equipment
+					}
+				}
 				}
 				search_filters = { FOCUS_FILTER_RESEARCH }
 		}
@@ -4396,11 +4386,11 @@
 			cost = 10
 			
 			completion_reward = {
-				add_timed_idea = { idea = arg_malbran days = 365 }
+				add_timed_idea = { idea = arg_malbran days = 45 }
 				ENG = {
 					add_opinion_modifier = { target = ARG modifier = arg_malbran }
 				}
-				add_stability = 0.1
+				add_stability = 0.15
 				
 			}
 			search_filters = { FOCUS_FILTER_INDUSTRY }
@@ -4423,6 +4413,15 @@
 					uses = 1
 					category = industry
 				}
+			ENG = {
+				add_ideas = industrial_coop
+				add_tech_bonus = {
+					name = industrial_bonus
+					bonus = 1
+					uses = 1
+					category = industry
+				}
+			}
 			}
 			search_filters = { FOCUS_FILTER_INDUSTRY FOCUS_FILTER_RESEARCH }
 		}
@@ -4438,6 +4437,9 @@
 			
 			completion_reward = {
 				add_ideas = naval_coop
+			ENG= {
+				add_ideas = naval_coop
+			}
 			}
 			search_filters = { FOCUS_FILTER_INDUSTRY }
 		}
@@ -4450,7 +4452,7 @@
 			relative_position_id = ARG_uk_industrial_coop
 			x = 1
 			y = 1			
-			cost = 10
+			cost = 5
 			
 			available = {
 				OR = {

--- a/common/national_focus/austria.txt
+++ b/common/national_focus/austria.txt
@@ -43,7 +43,7 @@ focus_tree = {
 				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = industrial_complex
-					level = 1
+					level = 2
 					instant_build = yes
 				}
 			}
@@ -51,15 +51,15 @@ focus_tree = {
 				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = industrial_complex
-					level = 1
+					level = 2
 					instant_build = yes
 				}
 			}
 			4 = {
-				add_extra_state_shared_building_slots = 1
+				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = industrial_complex
-					level = 1
+					level = 2
 					instant_build = yes
 				}
 			}
@@ -347,92 +347,90 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 	}
 	
-#	focus = {
-#		id = AUS_open_the_mittersill_mine
-#		icon = GFX_focus_generic_tungsten
-#		prerequisite = { focus = AUS_subsidize_STRABAG_construction }
-#		x = 6
-#		y = 1
-#		cost = 10
-#		ai_will_do = {
-#			factor = 10
-#		}
-#		
-#		available = {
-#			controls_state = 153
-#			has_tech = excavation_c
-#		}
-#		
-#		
-#		
-#		
-#		
-#		completion_reward = {
-#			add_resource = {
-#				type = tungsten
-#				amount = 6
-#				state = 153
-#			}
-#		}
-#		search_filters = { FOCUS_FILTER_INDUSTRY }
-#	}
-	
-#	focus = { #REPLACED BY DECISION
-#		id = AUS_expand_erzberg_mine
-#		icon = GFX_focus_generic_steel
-#		prerequisite = { focus = AUS_subsidize_STRABAG_construction }
-#		x = 10
-#		y = 1
-#		cost = 10
-#		ai_will_do = {
-#			factor = 10
-#		}
-#		
-#		available = {
-#			controls_state = 152
-#		}
-#		
-#		
-#		
-#		
-#		
-#		completion_reward = {
-#			add_resource = {
-#				type = steel
-#				amount = 12
-#				state = 152
-#			}
-#		}
-#		search_filters = { FOCUS_FILTER_INDUSTRY }
-#	}
-	
-#	focus = {
-#		id = AUS_expand_the_vienna_basin_oilfield
-#		icon = GFX_goal_generic_oil_refinery
-#		prerequisite = { focus = AUS_subsidize_STRABAG_construction }
-#		x = 12
-#		y = 1
-#		cost = 10
-#		ai_will_do = {
-#			factor = 8
-#		}
-#		
-#		available = {
-#			controls_state = 4
-#		}
-#		
-#		
-#		
-#		
-#		
-#		completion_reward = {
-#			add_resource = {
-#				type = oil
-#				amount = 4
-#				state = 4
-#			}
-#		}
-#	}
+	focus = {
+		id = AUS_open_the_mittersill_mine
+		icon = GFX_focus_generic_tungsten
+		prerequisite = { focus = AUS_subsidize_STRABAG_construction }
+		x = 6
+		y = 1
+		cost = 10
+		ai_will_do = {
+			factor = 10
+		}
+		
+		available = {
+			controls_state = 153
+			
+		}
+		
+		
+		
+		
+		
+		completion_reward = {
+			add_resource = {
+				type = tungsten
+				amount = 12
+				state = 153
+			}
+		}
+		search_filters = { FOCUS_FILTER_INDUSTRY }
+	}	
+	focus = { #REPLACED BY DECISION
+		id = AUS_expand_erzberg_mine
+		icon = GFX_focus_generic_steel
+		prerequisite = { focus = AUS_subsidize_STRABAG_construction }
+		x = 10
+		y = 1
+		cost = 10
+		ai_will_do = {
+			factor = 10
+		}
+		
+		available = {
+			controls_state = 152
+		}
+		
+		
+		
+		
+		
+		completion_reward = {
+			add_resource = {
+				type = steel
+				amount = 20
+				state = 152
+			}
+		}
+		search_filters = { FOCUS_FILTER_INDUSTRY }
+	}	
+	focus = {
+		id = AUS_expand_the_vienna_basin_oilfield
+		icon = GFX_goal_generic_oil_refinery
+		prerequisite = { focus = AUS_subsidize_STRABAG_construction }
+		x = 12
+		y = 1
+		cost = 10
+		ai_will_do = {
+			factor = 8
+		}
+		
+		available = {
+			controls_state = 4
+		}
+		
+		
+		
+		
+		
+		completion_reward = {
+			add_resource = {
+				type = oil
+				amount = 6
+				state = 4
+			}
+		}
+	}
 	
 	focus = {
 		id = AUS_extend_the_grossglockner_highway
@@ -456,6 +454,13 @@ focus_tree = {
 		
 		
 		completion_reward = {
+			848 = {
+				add_building_construction = {
+					type = infrastructure
+					level = 1
+					instant_build = yes
+				}
+			}
 			4 = {
 				add_building_construction = {
 					type = infrastructure

--- a/common/national_focus/belgium.txt
+++ b/common/national_focus/belgium.txt
@@ -36,6 +36,10 @@ focus_tree = {
 			factor = 10
 		}
         completion_reward = {
+			add_popularity = {
+    			ideology = communism
+    			popularity = 0.10
+			}
 			add_timed_idea = {
 				idea = internationalism
 				days = 900
@@ -64,6 +68,10 @@ focus_tree = {
 			}
 		}		
         completion_reward = {
+			add_popularity = {
+    			ideology = communism
+    			popularity = 0.05
+			}
 		add_war_support = 0.1
         add_political_power = 120
 		remove_ideas = tblra_pillarized_society
@@ -92,6 +100,10 @@ focus_tree = {
 			}
 		}
 		completion_reward = {
+			add_popularity = {
+    			ideology = communism
+    			popularity = 0.05
+			}
 			add_ideas = tblra_volunteer_corps
 			add_timed_idea = { idea = internationalism days = 1000 }
 		}
@@ -105,7 +117,7 @@ focus_tree = {
 		relative_position_id = tblra_communist_brigades
 		x = -1
 		y = 1
-		cost = 10
+		cost = 5
 		ai_will_do = {
 			factor = 5
 		}
@@ -157,7 +169,7 @@ focus_tree = {
 		relative_position_id = tblra_communist_brigades
 		x = 1
 		y = 1
-		cost = 3
+		cost = 5
 		ai_will_do = {
 			factor = 5
 		}
@@ -201,7 +213,7 @@ focus_tree = {
 		relative_position_id = tblra_communist_youth
         x = 0
         y = 1
-        cost = 10
+        cost = 8
 		ai_will_do = {
 			factor = 5
 		}		
@@ -212,7 +224,7 @@ focus_tree = {
 			add_ideas = tblra_communist_army
 			add_timed_idea = {
 				idea = tblra_purge_the_army
-				days = 218
+				days = 120
 			}
 			army_experience = -10
 			remove_ideas = tblra_linguistic_question_in_military
@@ -240,7 +252,7 @@ focus_tree = {
 			set_rule = { can_create_factions = yes }
 			add_stability = 0.05
 			add_war_support = 0.1
-			add_political_power = 50			
+			add_political_power = 100			
     	}
     	search_filters = { FOCUS_FILTER_STABILITY FOCUS_FILTER_POLITICAL FOCUS_FILTER_WAR_SUPPORT }
 	}	
@@ -252,7 +264,7 @@ focus_tree = {
         relative_position_id = tblra_support_pcf2
 		x = 1
         y = 1	
-        cost = 10
+        cost = 8
 		ai_will_do = {
 			factor = 7
 		}		
@@ -279,7 +291,7 @@ focus_tree = {
 				}
 				add_tech_bonus = {
 					name = motorized_rockets_tech_bonus_name
-					bonus = 0.25
+					bonus = 1
 					uses = 1
 					category = mot_rockets
 				}				
@@ -295,7 +307,7 @@ focus_tree = {
         relative_position_id = tblra_sign_pact_with_soviets
 	    x = -1
         y = 1
-        cost = 10
+        cost = 8
 		ai_will_do = {
 			factor = 5
 		}		
@@ -374,9 +386,43 @@ focus_tree = {
 		}
 		completion_reward = {
 			HOL = { country_event = { id = tblra.28 days = 1 } }
+			INS = { country_event = { id = tblra.28 days = 1 } }
 			custom_effect_tooltip = tblra_puppet_netherlands_tootip
 		}
 	}	
+	focus = { 
+        id = tblra_attack_Luxemburg
+        icon = GFX_goal_generic_forceful_treaty
+        prerequisite = { focus = tblra_puppet_netherlands}	
+        relative_position_id = tblra_puppet_netherlands
+		x = 0
+        y = 1
+        cost = 5
+		ai_will_do = {
+			factor = 2
+		}
+		available = {
+			has_government = communism
+			is_puppet = no
+			NOT = {
+				LUX = {
+					is_in_faction_with = BEL
+				}
+			}
+			LUX = {
+				exists = yes
+			}
+		}
+		completion_reward = {
+			ROOT = {
+				create_wargoal = {
+					type = take_state_focus
+					target = LUX
+					expire = 0
+				}
+			}
+		}
+	}
     focus = { 
         id = tblra_communist_propaganda_Benelux
         icon = GFX_postive_heroism
@@ -536,8 +582,6 @@ focus_tree = {
         prerequisite = { focus = tblra_independent_revolution focus = tblra_sign_pact_with_soviets }
 		available = {
 			has_government = communism
-			has_war = yes
-			is_in_faction = yes
 			OR = {
 				num_of_factories > 30
 				any_country = {
@@ -642,7 +686,7 @@ focus_tree = {
         prerequisite = { focus = tblra_form_coalition_government }
         mutually_exclusive = { focus = tblra_stay_neutral }
 		relative_position_id = tblra_form_coalition_government
-        cost = 10
+        cost = 5
 		ai_will_do = {
 			factor = 5
 		}		
@@ -663,7 +707,7 @@ focus_tree = {
 		relative_position_id = tblra_form_coalition_government		
         x = -1
         y = 1
-        cost = 10
+        cost = 5
 		ai_will_do = {
 			factor = 7
 		}		
@@ -703,7 +747,7 @@ focus_tree = {
 		relative_position_id = tblra_deterrence
         x = 0
         y = 1
-        cost = 10
+        cost = 8
 		ai_will_do = {
 			factor = 5
 		}
@@ -733,11 +777,11 @@ focus_tree = {
 			}
 		prerequisite = {focus = tblra_stay_neutral focus = tblra_democratic_influence focus = tblra_king_reaction}
         completion_reward = {
-			army_experience = -15
+			
             remove_ideas = tblra_linguistic_question_in_military
 			add_timed_idea = {
 				idea = tblra_divide_the_military
-				days = 180
+				days = 90
 			}			
         }
 		search_filters = { FOCUS_FILTER_MILITARY_IMPROVEMENT FOCUS_FILTER_POLITICAL }
@@ -2327,17 +2371,17 @@ focus_tree = {
 			}
 		6 = { is_owned_by = BEL }
         }		
-        cost = 10
+        cost = 8
 		ai_will_do = {
 			factor = 10		
 			}		
 		available_if_capitulated = yes
         completion_reward = {
             6 = {
-                add_extra_state_shared_building_slots = 1
+                add_extra_state_shared_building_slots = 2
                 add_building_construction = {
                     type = industrial_complex
-                    level = 1
+                    level = 2
                     instant_build = yes
                 }
             }
@@ -2472,6 +2516,41 @@ focus_tree = {
 					instant_build = yes
 				}
 			}
+			888 = {
+				add_building_construction = {
+					type = infrastructure
+					level = 1
+					instant_build = yes
+				}
+			}
+			889 = {
+				add_building_construction = {
+					type = infrastructure
+					level = 1
+					instant_build = yes
+				}
+			}
+			890 = {
+				add_building_construction = {
+					type = infrastructure
+					level = 1
+					instant_build = yes
+				}
+			}
+			768 = {
+				add_building_construction = {
+					type = infrastructure
+					level = 1
+					instant_build = yes
+				}
+			}
+			769 = {
+				add_building_construction = {
+					type = infrastructure
+					level = 1
+					instant_build = yes
+				}
+			}
 			if = { 
 				limit = {
 					has_dlc = "Together for Victory"
@@ -2502,7 +2581,7 @@ focus_tree = {
 		relative_position_id = tblra_urban_projects_capital
         x = -10
         y = 1
-        cost = 10 
+        cost = 8
  		ai_will_do = { 
  			factor = 1 
 		}
@@ -2532,7 +2611,7 @@ focus_tree = {
         completion_reward = {
 			add_resource = {
 				type = steel
-				amount = 4
+				amount = 5
 				state = 295
 			}
 			if = { 
@@ -2571,7 +2650,7 @@ focus_tree = {
 					}
 				}
 			}
-            has_tech = excavation3
+            has_tech = excavation2
 			OR ={
 				controls_state = 295
 				any_other_country = {
@@ -2592,7 +2671,7 @@ focus_tree = {
         completion_reward = {
             add_resource = {
                 type = steel
-                amount = 4
+                amount = 8
                 state = 295
             }
 			if = { 
@@ -2620,7 +2699,7 @@ focus_tree = {
 		relative_position_id = tblra_urban_projects_capital
         x = -8
         y = 1
-        cost = 10
+        cost = 8
 		ai_will_do = {
 			factor = 5			
 			}		
@@ -2660,12 +2739,12 @@ focus_tree = {
 			custom_effect_tooltip = TBLRA_congo_tree_tooltip		
             add_resource = {
                 type = rubber
-                amount = 6
+                amount = 2
                 state = 538
             }
 			add_resource = {
                 type = rubber
-                amount = 8
+                amount = 2
                 state = 538
             }
             add_resource = {
@@ -2675,7 +2754,7 @@ focus_tree = {
             }
             add_resource = {
                 type = rubber
-                amount = 3
+                amount = 2
                 state = 718
             }
 			if = { 
@@ -2741,20 +2820,26 @@ focus_tree = {
 		}	
 		available_if_capitulated = yes
         completion_reward = {
-			custom_effect_tooltip = TBLRA_congo_tree_tooltip		
+			custom_effect_tooltip = TBLRA_congo_tree_tooltip
+					
             add_resource = {
                 type = rubber
-                amount = 4
+                amount = 3
                 state = 538
             }
             add_resource = {
                 type = rubber
-                amount = 2
+                amount = 3
                 state = 295
             }
             add_resource = {
                 type = rubber
-                amount = 1
+                amount = 4
+                state = 888
+            }
+			add_resource = {
+                type = rubber
+                amount = 5
                 state = 718
             }
 			if = { 
@@ -2783,7 +2868,7 @@ focus_tree = {
 		relative_position_id = tblra_urban_projects_capital
 		x = -6
         y = 1
-        cost = 10
+        cost = 8
 		ai_will_do = {
 			factor = 5			
 			}		
@@ -2820,7 +2905,7 @@ focus_tree = {
 			custom_effect_tooltip = TBLRA_congo_tree_tooltip		
             add_resource = {
                 type = tungsten
-                amount = 5
+                amount = 3
                 state = 718
             }
             add_resource = {
@@ -2870,7 +2955,7 @@ focus_tree = {
 				}
 				}
 			}	
-            has_tech = excavation3
+            has_tech = excavation2
 			OR ={
 				AND ={
 					controls_state = 295
@@ -2890,12 +2975,12 @@ focus_tree = {
 			custom_effect_tooltip = TBLRA_congo_tree_tooltip		
             add_resource = {
                 type = tungsten
-                amount = 5
+                amount = 3
                 state = 718
             }
             add_resource = {
                 type = tungsten
-                amount = 1
+                amount = 4
                 state = 295
             }
 			if = { 
@@ -2940,7 +3025,7 @@ focus_tree = {
 					}
 				}
 			}	
-            has_tech = excavation4
+            has_tech = excavation3
 			OR ={
 				AND ={
 					controls_state = 295
@@ -2960,13 +3045,18 @@ focus_tree = {
 			custom_effect_tooltip = TBLRA_congo_tree_tooltip		
             add_resource = {
                 type = tungsten
-                amount = 5
+                amount = 2
                 state = 718
             }
             add_resource = {
                 type = tungsten
-                amount = 1
+                amount = 2
                 state = 295
+            }
+			add_resource = {
+                type = tungsten
+                amount = 4
+                state = 888
             }
 			if = { 
 				limit = {
@@ -3010,7 +3100,7 @@ focus_tree = {
 					}
 				}
 			}	
-            has_tech = excavation5
+            has_tech = excavation4
 			OR ={
 				AND ={
 					controls_state = 295
@@ -3030,13 +3120,33 @@ focus_tree = {
 			custom_effect_tooltip = TBLRA_congo_tree_tooltip		
             add_resource = {
                 type = tungsten
-                amount = 5
+                amount = 1
                 state = 718
             }
             add_resource = {
                 type = tungsten
                 amount = 1
                 state = 295
+            }
+			add_resource = {
+                type = tungsten
+                amount = 2
+                state = 888
+            }
+			add_resource = {
+                type = tungsten
+                amount = 2
+                state = 889
+            }
+			add_resource = {
+                type = tungsten
+                amount = 2
+                state = 769
+            }
+			add_resource = {
+                type = tungsten
+                amount = 2
+                state = 768
             }
 			if = { 
 				limit = {
@@ -3102,7 +3212,7 @@ focus_tree = {
 			295 = {
 				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
-					type = naval_base
+					type = dockyard
 					level = 2
 					province = 10968
 					instant_build = yes
@@ -3112,6 +3222,15 @@ focus_tree = {
 				add_extra_state_shared_building_slots = 1
 			}
 			718 = {
+				add_extra_state_shared_building_slots = 1
+			}
+			295 = {
+				add_extra_state_shared_building_slots = 1
+			}
+			890 = {
+				add_extra_state_shared_building_slots = 1
+			}
+			888 = {
 				add_extra_state_shared_building_slots = 1
 			}
 			if = { 
@@ -3170,10 +3289,10 @@ focus_tree = {
         completion_reward = {
 			custom_effect_tooltip = TBLRA_congo_tree_tooltip
             295 = {
-				add_extra_state_shared_building_slots = 1
+				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = industrial_complex
-					level = 1
+					level = 2
 					instant_build = yes
 				}
             }
@@ -3236,18 +3355,18 @@ focus_tree = {
         completion_reward = {
 			custom_effect_tooltip = TBLRA_congo_tree_tooltip
              538 = {
-				add_extra_state_shared_building_slots = 1
+				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = industrial_complex
-					level = 1
+					level = 2
 					instant_build = yes
 				}
             }
 			718 = {
-				add_extra_state_shared_building_slots = 1
+				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = industrial_complex
-					level = 1
+					level = 2
 					instant_build = yes
 				}
 			}
@@ -3439,10 +3558,10 @@ focus_tree = {
 			}		
         completion_reward = {		
 			6 = {
-				add_extra_state_shared_building_slots = 2
+				add_extra_state_shared_building_slots = 3
 				add_building_construction = {
 					type = dockyard
-					level = 1
+					level = 2
 					instant_build = yes
 				}
                 add_building_construction = {
@@ -3568,10 +3687,10 @@ focus_tree = {
 			}		
         completion_reward = {
             6 = {
-                add_extra_state_shared_building_slots = 1
+                add_extra_state_shared_building_slots = 3
                 add_building_construction = {
                     type = industrial_complex
-                    level = 1
+                    level = 2
                     instant_build = yes
                 }
             }
@@ -3597,6 +3716,7 @@ focus_tree = {
 			factor = 5			
 			}		
         completion_reward = {
+			add_ideas = tblra_Economic_Boom_of_Antwerp
             6 = {
                 add_extra_state_shared_building_slots = 1
                 add_building_construction = {
@@ -3632,7 +3752,7 @@ focus_tree = {
 			}
 		34 = { is_owned_by = BEL }
         }        
-		cost = 10
+		cost = 5
         completion_reward = {
             34 = {
                 add_building_construction = {
@@ -3680,7 +3800,7 @@ focus_tree = {
 		6 = { is_owned_by = BEL }
 		34 = { is_owned_by = BEL }
         }
-		cost = 10
+		cost = 5
 			ai_will_do = {
 			factor = 0	
 			modifier = {
@@ -3861,7 +3981,7 @@ focus_tree = {
 		relative_position_id = tblra_urban_projects_capital  
         x = 8
         y = 0
-        cost = 10
+        cost = 5
 		ai_will_do = {
 			factor = 6	
 			modifier = {
@@ -3874,11 +3994,11 @@ focus_tree = {
 			}			
 		}		
         completion_reward = {
-            army_experience = 5
+            army_experience = 25
 			add_doctrine_cost_reduction = {
 				name = land_doc_bonus
-				cost_reduction = 0.5
-				uses = 1
+				cost_reduction = 1
+				uses = 2
 				category = land_doctrine
 			}
         }
@@ -3891,7 +4011,7 @@ focus_tree = {
 		relative_position_id = tblra_begin_rearmement
         x = 2
         y = 0
-        cost = 15
+        cost = 10
 		ai_will_do = {
 			factor = 2
 			modifier = {
@@ -3904,12 +4024,12 @@ focus_tree = {
 			}			
 		}		
         completion_reward = {
-            army_experience = 10
+            army_experience = 50
 			add_war_support = 0.05
 			add_doctrine_cost_reduction = {
 				name = land_doc_bonus
-				cost_reduction = 0.5
-				uses = 1
+				cost_reduction = 1
+				uses = 2
 				category = land_doctrine
 			}
 			random_army_leader = { 
@@ -3957,9 +4077,7 @@ focus_tree = {
 				}
 			}
 		}
-		available = {
-			has_tech = interwar_antiair
-		}
+		
 		completion_reward = {
 			6 = {
 				add_building_construction = {
@@ -3988,7 +4106,7 @@ focus_tree = {
 		relative_position_id = tblra_form_air_guard_of_the_territory
         x = 0
         y = 1
-        cost = 10
+        cost = 5
 		ai_will_do = {
 			factor = 4			
 			}		
@@ -4026,12 +4144,13 @@ focus_tree = {
         cost = 10
 		available_if_capitulated = yes		
         completion_reward = {
-            add_tech_bonus = {  
+			add_tech_bonus = {  
                 name = motorized_bonus
                 bonus = 1
-                uses = 1
-				category = hospital_tech
+                uses = 2
+				category = motorized_equipment
 				}
+            
             add_tech_bonus = {  
                 name = motorized_bonus
                 bonus = 1
@@ -4129,7 +4248,7 @@ focus_tree = {
         x = 1
         y = 1
         prerequisite = { focus = tblra_begin_rearmement focus = tblra_accept_van_den_den_bergen_plan}
-        cost = 10
+        cost = 5
 		ai_will_do = {
 			factor = 5
 			modifier = {
@@ -4139,11 +4258,11 @@ focus_tree = {
 		}		
 		available_if_capitulated = yes
         completion_reward = {
-			army_experience = 5
+			army_experience = 25
 			add_doctrine_cost_reduction = {
 				name = land_doc_bonus
-				cost_reduction = 0.5
-				uses = 1
+				cost_reduction = 1
+				uses = 2
 				category = land_doctrine
 			}
 		}
@@ -4179,7 +4298,7 @@ focus_tree = {
 		}		
 		available_if_capitulated = yes
         completion_reward = {
-			army_experience = 5
+			army_experience = 25
             add_tech_bonus = {
                 name = infantry_artillery_bonus
                 bonus = 1
@@ -4193,7 +4312,7 @@ focus_tree = {
                 uses = 1
 				category = r56_jaeger_infantry_tech				
             }            
-            #add_ideas = tblra_reserve_mobilization
+            add_ideas = tblra_reserve_mobilization
 			set_technology = { bicycle_infantry = 1 }
 			division_template = {
 				name = "Cyclistes Frontière"		# border cycling units....with tank destroyers
@@ -4232,7 +4351,7 @@ focus_tree = {
 		relative_position_id = tblra_equipement_modernization
         x = 0
         y = 1
-        cost = 10
+        cost = 7
 		ai_will_do = {
 			factor = 5			
 			}		
@@ -4240,8 +4359,8 @@ focus_tree = {
         completion_reward = {
 			add_doctrine_cost_reduction = {
 				name = land_doc_bonus
-				cost_reduction = 0.5
-				uses = 1
+				cost_reduction = 1
+				uses = 3
 				category = land_doctrine
 			}
 		}
@@ -4254,13 +4373,13 @@ focus_tree = {
 		relative_position_id = tblra_equipement_modernization
         x = 1
         y = 2
-        cost = 10
+        cost = 5
 		ai_will_do = {
 			factor = 5			
 			}		
 		available_if_capitulated = yes
         completion_reward = {
-            army_experience = 5
+            army_experience = 25
             add_tech_bonus = {
                 name = infantry_artillery_bonus
                 bonus = 1
@@ -4283,11 +4402,11 @@ focus_tree = {
 			}		
 		available_if_capitulated = yes
         completion_reward = {
-			army_experience = 5
+			army_experience = 25
             add_tech_bonus = {
                 name = infantry_artillery_bonus
                 bonus = 1
-                uses = 1
+                uses = 2
                 category = artillery
 			}				
         }
@@ -4320,9 +4439,9 @@ focus_tree = {
 		}
 		available = {
 			has_capitulated = no
-			is_in_faction_with = FRA
+			
 			FRA = {
-				has_capitulated = no
+				
 				OR = {
 					controls_state = 18
 					controls_state = 29
@@ -4470,7 +4589,7 @@ focus_tree = {
         prerequisite = { focus = tblra_experimental_weaponry }
         prerequisite = { focus = tblra_prototype_weapons }
 		available = {
-			num_of_factories > 50
+			num_of_factories > 40
 		}
 		relative_position_id = tblra_experimental_weaponry
         x = -1
@@ -4616,7 +4735,7 @@ focus_tree = {
 			}		
 		available_if_capitulated = yes	
         completion_reward = {
-            air_experience = -10
+            air_experience = 10
             add_tech_bonus = {
                 name = antiair_tech_bonus_name
                 bonus = 1
@@ -4657,7 +4776,7 @@ focus_tree = {
 		relative_position_id = tblra_van_overstraeten_aa_guns
         x = 3
         y = 0
-        cost = 10
+        cost = 8
 		ai_will_do = {
 			factor = 7			
 		}		
@@ -4666,22 +4785,20 @@ focus_tree = {
 			BEL ={
             	controls_state = 295
 				}
-			NOT = {
-				BEL = {controls_state = 6}	
-			}
+			
         }		
         completion_reward = {
-        	air_experience = 10
+        	air_experience = 100
 			add_doctrine_cost_reduction = {
 				name = air_doc_bonus
-				cost_reduction = 0.5
+				cost_reduction = 1
 				uses = 2
 				category = air_doctrine
 			}
         	295 = {
             	add_building_construction = {
                 	type = air_base
-                	level = 1
+                	level = 5
                 	instant_build = yes
                 }
             }
@@ -4696,7 +4813,7 @@ focus_tree = {
 		relative_position_id = tblra_air_force_congo
         x = 3
         y = 0	
-        cost = 10
+        cost = 6
 		ai_will_do = {
 			factor = 4
 			}		
@@ -4708,7 +4825,7 @@ focus_tree = {
 		6 = { is_owned_by = BEL }
         }		
         completion_reward = {
-			air_experience = 25
+			air_experience = 50
 			if = {
 				limit = {
 					has_dlc = "La Resistance"
@@ -4716,14 +4833,14 @@ focus_tree = {
 			}	
 			add_doctrine_cost_reduction = {
 				name = air_doc_bonus
-				cost_reduction = 0.5
+				cost_reduction = 1
 				uses = 2
 				category = air_doctrine
 			}
 			6 = {
 				add_building_construction = {
 					type = air_base
-					level = 2
+					level = 5
 					instant_build = yes
 				}
 			}
@@ -4749,7 +4866,7 @@ focus_tree = {
 		}
         prerequisite = { focus = tblra_revise_air_doctrine focus = tblra_air_force_congo}
         completion_reward = {
-            air_experience = 5
+            air_experience = 25
 			add_tech_bonus = {
 				name = tblra_Renard_fighters
 				bonus = 1
@@ -4784,7 +4901,7 @@ focus_tree = {
 		}
         prerequisite =  { focus = tblra_revise_air_doctrine}
         completion_reward = {
-            air_experience = 5
+            air_experience = 25
 			add_tech_bonus = {
 				name = tblra_revise_air_doctrine
 				bonus = 1
@@ -4793,7 +4910,7 @@ focus_tree = {
 			}
 				add_tech_bonus = {
 					name = tblra_multipurpose_bombers
-					bonus = 0.5
+					bonus = 1
 					uses = 1
 					category = air_equipment
 				}				
@@ -4808,7 +4925,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = tblra_air_force_congo
 
-		cost = 7
+		cost = 5
 
 		ai_will_do = {
 			factor = 6
@@ -4842,7 +4959,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = tblra_license_production
 
-		cost = 7
+		cost = 5
 
 		ai_will_do = {
 			factor = 20
@@ -4915,7 +5032,7 @@ focus_tree = {
 		mutually_exclusive = { focus = tblra_fighter_license}		
         x = 1
         y = 1
-        cost = 8
+        cost = 5
 		ai_will_do = {
 			factor = 4
 		}		
@@ -4980,7 +5097,7 @@ focus_tree = {
 		prerequisite = {focus = tblra_SABCAs_bombers focus = tblra_fighter_license }
         x = -2
         y = 1
-        cost = 10
+        cost = 5
 		ai_will_do = {
 			factor = 4	
 				modifier = {
@@ -5079,7 +5196,7 @@ focus_tree = {
         x = -1
         y = 1
         completion_reward = {
-			air_experience = 5
+			air_experience = 25
         	add_tech_bonus = {
             	name = CAS_bonus
             	bonus = 1
@@ -5105,7 +5222,7 @@ focus_tree = {
         x = 1
         y = 1
         completion_reward = {
-        	air_experience = 5
+        	air_experience = 25
 			add_tech_bonus = {
 				name = tblra_rule_the_sea_through_the_sky
 				bonus = 1
@@ -5140,7 +5257,7 @@ focus_tree = {
        		34 = {
 	            add_building_construction = {
 	                type = air_base
-	                level = 3
+	                level = 5
 	                instant_build = yes
 	            }
 	        }
@@ -5189,10 +5306,10 @@ focus_tree = {
         }	
         completion_reward = {
 			6 = {
-				add_extra_state_shared_building_slots = 2
+				add_extra_state_shared_building_slots = 3
 				add_building_construction = {
 					type = dockyard
-					level = 2
+					level = 3
 					instant_build = yes
 				}
 			}
@@ -5384,7 +5501,7 @@ focus_tree = {
 			add_tech_bonus = {
 				name = ss_bonus
 				bonus = 1
-				uses = 1
+				uses = 2
 				technology = basic_submarine_snorkel
 				technology = improved_submarine_snorkel
 			}
@@ -5443,12 +5560,12 @@ focus_tree = {
         prerequisite = { focus = tblra_expand_the_navy }
 		prerequisite = { focus = tblra_Foreign_aviation_studies }
 		completion_reward = {
-        	navy_experience = 10
-			air_experience = 10
+        	navy_experience = 25
+			air_experience = 25
             add_tech_bonus = {
 				name = capital_ships_bonus
 				bonus = 1
-				uses = 1
+				uses = 2
 				category = cv_tech
             }
         }
@@ -5527,8 +5644,8 @@ focus_tree = {
 		completion_reward = {
 			add_tech_bonus = {
 				name = industrial_bonus
-				bonus = 1
-				uses = 2
+				bonus = 0.5
+				uses = 3
 				category = naval_gunnery_tech
 			}			
 		}
@@ -5541,7 +5658,7 @@ focus_tree = {
 		icon = GFX_goal_generic_occupy_states_coastal
 		x = 0
 		y = 1
-		cost = 10
+		cost = 5
 		ai_will_do = {
 			factor = 4
 		}

--- a/common/national_focus/brazil.txt
+++ b/common/national_focus/brazil.txt
@@ -24,7 +24,7 @@ focus_tree = {
 		icon = GFX_focus_bra_voice_of_brasil
 		x = 3
 		y = 0
-		cost = 5
+		cost = 8
 		ai_will_do = {
 			factor = 10
 		}
@@ -47,7 +47,7 @@ focus_tree = {
 		x = 0
 		y = 1
 		relative_position_id = bra_a_voz_do_brasil
-		cost = 5
+		cost = 7
 		ai_will_do = {
 			factor = 10
 		}
@@ -66,7 +66,7 @@ focus_tree = {
 		NOT = { has_idea = bra_1930 }
 		}
 		relative_position_id = bra_a_voz_do_brasil
-		cost = 5
+		cost = 9
 		completion_reward = {
 			if = {
 				limit = {
@@ -84,9 +84,9 @@ focus_tree = {
 		x = 9
 		y = 2
 		relative_position_id = bra_a_voz_do_brasil
-		cost = 5
+		cost = 8
 		completion_reward = {
-			army_experience = 10
+			army_experience = 25
 			add_ideas = bra_consegnac_idea
 		}
 		search_filters = { FOCUS_FILTER_MILITARY_IMPROVEMENT }
@@ -104,7 +104,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			add_political_power = 120
+			add_political_power = 100
 			country_event = { days = 1 id = bra.2 }
 			custom_effect_tooltip = bra_aviso_tooltip
 		}
@@ -123,7 +123,7 @@ focus_tree = {
 		x = 0
 		y = 1
 		relative_position_id = bra_polaca
-		cost = 14.30
+		cost = 10
 		ai_will_do = {
 			factor = 50
 			modifier = {
@@ -138,7 +138,7 @@ focus_tree = {
 			}
 		}
 		completion_reward = {
-			add_named_threat = { threat = 0.5 name = bra_monarquia_focus_t }
+			add_named_threat = { threat = 1 name = bra_monarquia_focus_t }
 			remove_ideas = bra_instabilidade
 			hidden_effect = {
 				country_event = { days = 1 id = bra.5 }
@@ -201,7 +201,7 @@ focus_tree = {
 				factor = 0
 			}
 		}
-		cost = 5
+		cost = 10
 
 		bypass = {
 			NOT = {
@@ -242,7 +242,7 @@ focus_tree = {
 		x = 0
 		y = 2
 		relative_position_id = bra_2_prestes_column
-		cost = 5
+		cost = 7
 		ai_will_do = {
 			factor = 0.5
 			modifier = {
@@ -298,7 +298,7 @@ focus_tree = {
 				factor = 0
 			}
 		}
-		cost = 5
+		cost = 10
 		available = { 
 			has_country_leader = { 
 				character = BRA_getulio_vargas
@@ -351,7 +351,7 @@ focus_tree = {
 				factor = 0
 			}
 		}
-		cost = 5
+		cost = 7
 		completion_reward = {
 			swap_ideas = { remove_idea = bra_antropofagia_fasc_1 add_idea = bra_antropofagia_fasc_2 }
 		}
@@ -377,7 +377,7 @@ focus_tree = {
 				factor = 1
 			}
 		}
-		cost = 5
+		cost = 8
 
 		bypass = {
 			NOT = {
@@ -414,7 +414,7 @@ focus_tree = {
 		relative_position_id = bra_estado_novo
 		x = 0
 		y = 1
-		cost = 5
+		cost = 7
 		ai_will_do = {
 			factor = 0.5
 		}
@@ -439,7 +439,7 @@ focus_tree = {
 		ai_will_do = {
 			factor = 25
 		}
-		cost = 5
+		cost = 8
 
 		bypass = {
 			NOT = {
@@ -477,7 +477,7 @@ focus_tree = {
 		x = 0
 		y = 1
 
-		cost = 5
+		cost = 7
 		completion_reward = {
 			swap_ideas = { remove_idea = bra_antropofagia_dem_1 add_idea = bra_antropofagia_dem_2 }
 		}
@@ -800,7 +800,7 @@ focus_tree = {
 		x = -1
 		y = 2
 		relative_position_id = bra_tecnocratic_reform
-		cost = 10
+		cost = 5
 		completion_reward = {
 			set_rule = { can_send_volunteers = yes }
 			add_ideas = { bra_feb_idea }
@@ -819,7 +819,7 @@ focus_tree = {
 		completion_reward = {
 			add_tech_bonus = {
 				name = industrial_bonus
-				bonus = 0.5
+				bonus = 1
 				uses = 1
 				category = industry
 			}
@@ -839,7 +839,7 @@ focus_tree = {
 		completion_reward = {
 			add_tech_bonus = {
 				name = electronics_bonus
-				bonus = 0.5
+				bonus = 1
 				uses = 1
 				category = electronics
 			}
@@ -858,7 +858,7 @@ focus_tree = {
 		completion_reward = {
 			add_tech_bonus = {
 				name = industrial_bonus
-				bonus = 0.5
+				bonus = 1
 				uses = 1
 				category = industry
 			}
@@ -876,7 +876,7 @@ focus_tree = {
 		completion_reward = {
 			add_tech_bonus = {
 				name = electronics_bonus
-				bonus = 0.5
+				bonus = 1
 				uses = 1
 				category = electronics
 			}
@@ -925,12 +925,12 @@ focus_tree = {
 		relative_position_id = bra_iti
 		x = 0
 		y = 1
-		cost = 5
+		cost = 10
 		completion_reward = {
 			swap_ideas = { remove_idea = bra_federal_universities_idea add_idea = bra_federal_universities_idea_2 }
 				add_tech_bonus = {
 					name = electronics_bonus
-					bonus = 0.5
+					bonus = 1
 					uses = 1
 					category = electronics
 				}
@@ -944,16 +944,14 @@ focus_tree = {
 		relative_position_id = bra_more_federal_universities
 		x = 0
 		y = 1
-		available = {
-			num_of_factories > 75
-		}
+		
 		cost = 10
 		completion_reward = {
-			add_research_slot = 1
+			
 			add_tech_bonus = {
 				name = secret_bonus
-				bonus = 0.5
-				uses = 1
+				bonus = 1
+				uses = 2
 				category = electronics
 				category = rocketry
 			}
@@ -965,8 +963,8 @@ focus = {
 		icon = GFX_goal_generic_nuclear_energy
 		prerequisite = { focus = bra_secret_research }
 		available = {
-			is_major = yes
-			num_of_factories > 80
+			
+			num_of_factories > 60
 		}
 		relative_position_id = bra_secret_research
 		x = 0
@@ -1040,8 +1038,8 @@ focus = {
 		navy_experience = 10
 			add_doctrine_cost_reduction = {
 				name = naval_doctrine_tech_bonus_name
-				cost_reduction = 0.5
-				uses = 1
+				cost_reduction = 1
+				uses = 2
 				category = naval_doctrine
 			}
 		}
@@ -1056,7 +1054,7 @@ focus = {
 		y = 1
 		cost = 5
 		completion_reward = {
-			navy_experience = 10
+			navy_experience = 25
 			create_navy_leader = {
 				name = "José Isaías de Noronha"
 				picture = "gfx/leaders/South America/Portrait_South_America_Generic_navy_1.dds"
@@ -1069,7 +1067,7 @@ focus = {
 			}
 			add_doctrine_cost_reduction = {
 				name = naval_doctrine_tech_bonus_name
-				cost_reduction = 0.5
+				cost_reduction = 1
 				uses = 1
 				category = naval_doctrine
 			}
@@ -1085,7 +1083,7 @@ focus = {
 		y = 1
 		cost = 10
 		completion_reward = {
-			navy_experience = 10
+			navy_experience = 25
 			add_tech_bonus = {
 				name = ss_bonus
 				bonus = 1
@@ -1164,7 +1162,7 @@ focus = {
 					add_extra_state_shared_building_slots = 3
 					add_building_construction = {
 						type = dockyard
-						level = 3
+						level = 2
 						instant_build = yes
 					}
 					add_building_construction = {
@@ -1184,15 +1182,15 @@ focus = {
 		relative_position_id = bra_consegnac
 		x = 3
 		y = 1
-		cost = 10
+		cost = 7
 		available = {
 
 		}
 		completion_reward = {
-			army_experience = 15
+			army_experience = 25
 			add_doctrine_cost_reduction = {
 				name = land_doc_bonus
-				cost_reduction = 0.4
+				cost_reduction = 1
 				uses = 1
 				category = land_doctrine
 			}
@@ -1218,7 +1216,7 @@ focus = {
 		y = 1
 		cost = 10
 		completion_reward = {
-			army_experience = 10
+			army_experience = 25
 			every_army_leader = {
 				add_planning = 1
 			}
@@ -1246,7 +1244,7 @@ focus = {
 			add_ideas = bra_ana_mineira_idea
 			add_doctrine_cost_reduction = {
 				name = land_doc_bonus
-				cost_reduction = 0.5
+				cost_reduction = 1
 				uses = 1
 				category = land_doctrine
 			}
@@ -1264,13 +1262,13 @@ focus = {
 		completion_reward = {
 			add_tech_bonus = {
 				name = infantry_weapons_bonus
-				bonus = 0.5
+				bonus = 1
 				uses = 1
 				category = infantry_weapons
 			}
 			add_doctrine_cost_reduction = {
 				name = land_doc_bonus
-				cost_reduction = 0.25
+				cost_reduction = 1
 				uses = 1
 				category = land_doctrine
 			}
@@ -1289,13 +1287,13 @@ focus = {
 		completion_reward = {
 		add_tech_bonus = {
 				name = infantry_weapons_bonus
-				bonus = 0.5
+				bonus = 1
 				uses = 1
 				category = artillery
 			}
 			add_doctrine_cost_reduction = {
 				name = land_doc_bonus
-				cost_reduction = 0.25
+				cost_reduction = 1
 				uses = 1
 				category = land_doctrine
 			}
@@ -1314,7 +1312,7 @@ focus = {
 		completion_reward = {
 			add_doctrine_cost_reduction = {
 				name = land_doc_bonus
-				cost_reduction = 0.5
+				cost_reduction = 1
 				uses = 1
 				category = land_doctrine
 			}
@@ -1335,7 +1333,7 @@ focus = {
 			add_ideas = bra_ana_paulista_idea
 			add_doctrine_cost_reduction = {
 				name = land_doc_bonus
-				cost_reduction = 0.5
+				cost_reduction = 1
 				uses = 1
 				category = land_doctrine
 			}
@@ -1353,13 +1351,13 @@ focus = {
 		completion_reward = {
 			add_doctrine_cost_reduction = {
 				name = land_doc_bonus
-				cost_reduction = 0.25
+				cost_reduction = 1
 				uses = 1
 				category = land_doctrine
 			}
 			add_tech_bonus = {
 				name = motorized_bonus
-				bonus = 0.5
+				bonus = 1
 				uses = 1
 				category = cat_mechanized_equipment
 			}
@@ -1378,13 +1376,13 @@ focus = {
 		completion_reward = {
 			add_doctrine_cost_reduction = {
 				name = land_doc_bonus
-				cost_reduction = 0.25
+				cost_reduction = 1
 				uses = 1
 				category = land_doctrine
 			}
 			add_tech_bonus = {
 				name = armor_bonus
-				bonus = 0.5
+				bonus = 1
 				uses = 1
 				category = armor
 			}
@@ -1403,7 +1401,7 @@ focus = {
 		completion_reward = {
 			add_doctrine_cost_reduction = {
 				name = land_doc_bonus
-				cost_reduction = 0.5
+				cost_reduction = 1
 				uses = 1
 				category = land_doctrine
 			}
@@ -1419,7 +1417,7 @@ focus = {
 		relative_position_id = bra_consegnac
 		x = 0
 		y = 1
-		cost = 10
+		cost = 5
 		completion_reward = {
 		air_experience = 25
 			random_owned_controlled_state = {
@@ -1453,7 +1451,7 @@ focus = {
 			}
 			add_doctrine_cost_reduction = {
 				name = air_doctrine_tech_bonus_name
-				cost_reduction = 0.5
+				cost_reduction = 1
 				uses = 1
 				category = air_doctrine
 			}
@@ -1518,12 +1516,12 @@ focus = {
 		y = 1
 		cost = 10
 		completion_reward = {
-		air_experience = 10
+		air_experience = 25
 			add_tech_bonus = {
 				name = fighter_bonus
 				bonus = 1
 				uses = 1
-				category = cas_bomber
+				category = air_equipment
 			}
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH }
@@ -1667,7 +1665,7 @@ focus = {
 		relative_position_id = bra_sub_priv
 		x = 0
 		y = 1
-		cost = 5
+		cost = 8
 		completion_reward = {
 			swap_ideas = { remove_idea = bra_eficiencia_1 add_idea = bra_eficiencia_2 }
 			
@@ -1723,7 +1721,7 @@ focus = {
 		relative_position_id = bra_IRFM
 		x = 0
 		y = 1
-		cost = 10
+		cost = 5
 		
 		completion_reward = {
 			random_owned_controlled_state = {
@@ -2099,7 +2097,7 @@ focus = {
 		relative_position_id = bra_itabira
 		x = -1
 		y = 1
-		cost = 5
+		cost = 10
 		completion_reward = {
 			add_ideas = bra_salte_idea
 		}
@@ -2351,8 +2349,8 @@ focus = {
 		y = 1
 		cost = 10
 		available = {
-			num_of_factories > 100
-			is_major = yes
+			
+			
 		}
 		completion_reward = {
 			add_research_slot = 1
@@ -2366,7 +2364,7 @@ focus = {
 		relative_position_id = bra_gerdau
 		x = 1
 		y = 1
-		cost = 5
+		cost = 10
 		completion_reward = {
 			random_owned_controlled_state = {
                 prioritize = { 495 }
@@ -4125,7 +4123,7 @@ focus = {
 		relative_position_id = bra_cmvrg
 		x = 1
 		y = 1
-		cost = 5
+		cost = 10
 		completion_reward = {
 			add_ideas = bra_ciclocana_idea
 			

--- a/common/national_focus/bulgaria.txt
+++ b/common/national_focus/bulgaria.txt
@@ -41,7 +41,7 @@ focus_tree = {
 		icon = GFX_goal_generic_production2
 		x = 12
 		y = 0
-		cost = 5
+		cost = 10
 
 		available = {
 
@@ -50,10 +50,10 @@ focus_tree = {
 		search_filters = {FOCUS_FILTER_INDUSTRY FOCUS_FILTER_RESEARCH}
 		completion_reward = {
 			add_ideas = BUL_national_industry_01
-
+			add_political_power = 35
 			add_tech_bonus = {
 				name = BUL_acquire_modern_tools
-				bonus = 0.5
+				bonus = 1
 				uses = 1
 				category = industry
 			}
@@ -68,7 +68,7 @@ focus_tree = {
 		relative_position_id = BUL_acquire_modern_tools
 		x = -9
 		y = 1
-		cost = 5
+		cost = 10
 
 		available = {
 
@@ -125,14 +125,14 @@ focus_tree = {
 				limit = {
 					free_building_slots = {
 						building = industrial_complex
-						size > 2
+						size > 3
 						include_locked = yes
 					}
 				}
-				add_extra_state_shared_building_slots = 2
+				add_extra_state_shared_building_slots = 3
 				add_building_construction = {
 					type = industrial_complex
-					level = 2
+					level = 3
 					instant_build = yes
 				}
 			}
@@ -324,7 +324,7 @@ focus_tree = {
 		relative_position_id = BUL_expand_the_tobacco_industry
 		x = 0
 		y = 1
-		cost = 10
+		cost = 8
 		mutually_exclusive = { focus = BUL_utmost_optimization }
 
 		available = {
@@ -399,7 +399,7 @@ focus_tree = {
 
 
 		available = {
-			num_of_civilian_factories > 16
+			
 		}
 		
 		search_filters = {FOCUS_FILTER_INDUSTRY}
@@ -439,7 +439,7 @@ focus_tree = {
 
 		available = {
 			NOT = { has_idea = BUL_second_national_catastrophe }
-			num_of_factories > 29
+			
 		}
 		
 		search_filters = {FOCUS_FILTER_INDUSTRY}
@@ -556,16 +556,16 @@ focus_tree = {
 		cost = 10
 
 		available = {
-			controls_state = 48
+			
 		}
 		
 		search_filters = {FOCUS_FILTER_INDUSTRY FOCUS_FILTER_RESEARCH FOCUS_FILTER_STEEL}
 		completion_reward = {
 			add_tech_bonus = {
 				name = BUL_mineral_extraction_in_the_rhodopes
-				ahead_reduction = 2
+				ahead_reduction = 0
 			    bonus = 1.0
-			    uses = 1
+			    uses = 2
 			    category = industry
 			}
 			if = {
@@ -610,7 +610,7 @@ focus_tree = {
 		cost = 5
 
 		available = {
-			has_tech = excavation2
+			
 			OR = {
 				controls_state = 48
 				controls_state = 212
@@ -642,8 +642,7 @@ focus_tree = {
 		cost = 10
 
 		available = {
-			has_tech = excavation3
-			controls_state = 48
+			
 		}
 		
 		search_filters = {FOCUS_FILTER_INDUSTRY FOCUS_FILTER_RESEARCH}
@@ -686,7 +685,7 @@ focus_tree = {
 		relative_position_id = BUL_acquire_modern_tools
 		x = -5
 		y = 1
-		cost = 5
+		cost = 10
 
 		available = {
 
@@ -694,12 +693,12 @@ focus_tree = {
 		
 		search_filters = { FOCUS_FILTER_MILITARY_IMPROVEMENT FOCUS_FILTER_INDUSTRY}
 		completion_reward = {
-			air_experience = 10
+			air_experience = 25
 			212 = {
-				add_extra_state_shared_building_slots = 2
+				add_extra_state_shared_building_slots = 3
 				add_building_construction = {
 					type = industrial_complex
-					level = 1
+					level = 2
 					instant_build = yes
 				}
 				add_building_construction = {
@@ -728,10 +727,10 @@ focus_tree = {
 		
 		search_filters = { FOCUS_FILTER_MILITARY_IMPROVEMENT FOCUS_FILTER_RESEARCH}
 		completion_reward = {
-			air_experience = 15
+			air_experience = 25
 			add_doctrine_cost_reduction = {
 				name = BUL_pilot_training_program
-				cost_reduction = 0.65
+				cost_reduction = 1
 				uses = 2
 				category = air_doctrine
 			}
@@ -814,7 +813,7 @@ focus_tree = {
 			add_tech_bonus = {
 				name = BUL_reorganize_the_military_industry
 			    bonus = 1.0
-			    uses = 1
+			    uses = 2
 			    category = infantry_weapons
 				category = artillery
 			}
@@ -889,8 +888,8 @@ focus_tree = {
 				name = BUL_darzhavna_samoletna_fabrika
 			    bonus = 1.0
 			    uses = 2
-				category = cas_bomber
-				category = naval_bomber
+				category = air_equipment
+				
 			}
 		}
 	}
@@ -981,10 +980,10 @@ focus_tree = {
 		search_filters = {FOCUS_FILTER_INDUSTRY FOCUS_FILTER_RESEARCH}
 		completion_reward = {
 			212 = {
-				add_extra_state_shared_building_slots = 1
+				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = arms_factory
-					level = 1
+					level = 2
 					instant_build = yes
 				}
 			}
@@ -1245,12 +1244,12 @@ focus_tree = {
 		
 		search_filters = {FOCUS_FILTER_RESEARCH}
 		completion_reward = {
-			army_experience = 15
-			navy_experience = 15
-			air_experience = 15
+			army_experience = 25
+			navy_experience = 25
+			air_experience = 25
 			add_doctrine_cost_reduction = {
 				name = BUL_vasil_levsky_national_military_university
-				cost_reduction = 0.35
+				cost_reduction = 1
 				uses = 2
 				category = land_doctrine
 				category = naval_doctrine
@@ -1280,14 +1279,7 @@ focus_tree = {
 		
 		search_filters = { FOCUS_FILTER_MILITARY_IMPROVEMENT FOCUS_FILTER_MANPOWER FOCUS_FILTER_INDUSTRY}
 		completion_reward = {
-			random_core_state = {
-				add_extra_state_shared_building_slots = 2
-				add_building_construction = {
-					type = arms_factory
-					level = 2
-					instant_build = yes
-				}
-			}
+			
 			if = {
 				limit = { has_idea = BUL_bulgarian_army_01 }
 				swap_ideas = {
@@ -1328,10 +1320,10 @@ focus_tree = {
 		
 		search_filters = { FOCUS_FILTER_MILITARY_IMPROVEMENT FOCUS_FILTER_RESEARCH}
 		completion_reward = {
-			army_experience = 15
+			army_experience = 25
 			add_doctrine_cost_reduction = {
 				name = BUL_national_military_academy
-				cost_reduction = 0.5
+				cost_reduction = 1
 				uses = 1
 				category = land_doctrine
 			}
@@ -1369,8 +1361,8 @@ focus_tree = {
 		completion_reward = {
 			add_tech_bonus = {
 				name = BUL_war_logistics
-			    bonus = 0.5
-			    ahead_reduction = 2
+			    bonus = 1
+			    ahead_reduction = 1
 			    uses = 2
 				category = support_tech
 			}
@@ -1473,7 +1465,7 @@ focus_tree = {
 		relative_position_id = BUL_negotiate_bulgarian_rearmament
 		x = 12
 		y = 1
-		cost = 10
+		cost = 5
 
 		available = {
 			NOT = { has_idea = BUL_army_restrictions }
@@ -1481,10 +1473,10 @@ focus_tree = {
 		
 		search_filters = {FOCUS_FILTER_RESEARCH}
 		completion_reward = {
-			navy_experience = 15
+			navy_experience = 25
 			add_doctrine_cost_reduction = {
 				name = BUL_a_black_sea_fleet
-				cost_reduction = 0.35
+				cost_reduction = 1
 				uses = 1
 				category = naval_doctrine
 			}
@@ -2200,7 +2192,7 @@ focus_tree = {
 		relative_position_id = BUL_a_black_sea_fleet
 		x = -1
 		y = 1
-		cost = 10
+		cost = 8
 
 		available = {
 
@@ -2234,6 +2226,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_MILITARY_IMPROVEMENT FOCUS_FILTER_INDUSTRY FOCUS_FILTER_MILITARY_EQUIPMENT }
 		completion_reward = {
 			211 = {
+				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = dockyard
 					level = 2
@@ -2274,8 +2267,8 @@ focus_tree = {
 		
 		search_filters = {FOCUS_FILTER_RESEARCH}
 		completion_reward = {
-			army_experience = 15
-			navy_experience = 15
+			army_experience = 25
+			navy_experience = 25
 			add_tech_bonus = {
 				name = BUL_strike_from_the_seas
 			    bonus = 1.0
@@ -2302,7 +2295,7 @@ focus_tree = {
 		
 		search_filters = {FOCUS_FILTER_INDUSTRY}
 		completion_reward = {
-			navy_experience = 15
+			navy_experience = 25
 			211 = {
 				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
@@ -2365,7 +2358,7 @@ focus_tree = {
 		relative_position_id = BUL_a_black_sea_fleet
 		x = 2
 		y = 2
-		cost = 10
+		cost = 8
 
 		available = {
 			any_controlled_state = {
@@ -2419,7 +2412,7 @@ focus_tree = {
 		relative_position_id = BUL_an_aegean_sea_fleet
 		x = 0
 		y = 1
-		cost = 10
+		cost = 8
 		mutually_exclusive = { focus = BUL_strike_from_the_seas }
 
 		available = {
@@ -2431,13 +2424,13 @@ focus_tree = {
 			navy_experience = 25
 			add_doctrine_cost_reduction = {
 				name = BUL_a_powerful_bulgarian_navy
-			    cost_reduction = 0.5
+			    cost_reduction = 1
 			    uses = 1
 			    category = naval_doctrine
 			}
 			add_tech_bonus = {
 				name = BUL_a_powerful_bulgarian_navy
-				bonus = 0.75
+				bonus = 1
 				uses = 1
 				category = bb_tech
 			}
@@ -2463,13 +2456,13 @@ focus_tree = {
 			navy_experience = 25
 			add_doctrine_cost_reduction = {
 				name = BUL_modern_tactics
-			    cost_reduction = 0.5
+			    cost_reduction = 1
 			    uses = 2
 			    category = naval_doctrine
 			}
 			add_tech_bonus = {
 				name = BUL_modern_tactics
-			    bonus = 0.75
+			    bonus = 1
 			    uses = 1
 			    category = naval_air
 			}

--- a/common/national_focus/canada.txt
+++ b/common/national_focus/canada.txt
@@ -89,10 +89,9 @@
 			add_political_power = 100
 			custom_effect_tooltip = available_political_advisor
 			show_ideas_tooltip = CAN_henry_angus
-			add_timed_idea = {
-			idea = CAN_rowell_sirois_commission_idea
-			days = 1370
-			}
+			add_ideas = CAN_rowell_sirois_commission_idea
+			
+			
 		}
 	
 	}
@@ -154,7 +153,7 @@
 		x = 0
 		y = 1		
 
-		cost = 10
+		cost = 5
 
 		available_if_capitulated = yes
 
@@ -206,7 +205,7 @@
 		available_if_capitulated = yes
 
 		completion_reward = {
-			add_political_power = 25
+			add_political_power = 50
 			custom_effect_tooltip = available_political_advisor
 			show_ideas_tooltip = CAN_c_d_howe
 		}
@@ -1583,8 +1582,8 @@
 		}
 
 		available = {
-			num_of_factories > 50
-			is_subject = no
+			
+			
 		}
 		
 		bypass = {

--- a/common/national_focus/chile.txt
+++ b/common/national_focus/chile.txt
@@ -2306,7 +2306,7 @@ focus_tree = {
 						OR = {
 							has_government = fascism
 							has_government = communism
-							has_government = democracy
+							
 						
 						}
 					}
@@ -2323,7 +2323,7 @@ focus_tree = {
 							OR = {
 							has_government = fascism
 							has_government = communism
-							has_government = democracy
+							
 							}
 						}
 					}
@@ -2339,8 +2339,7 @@ focus_tree = {
 					ARG = {
 						OR = {
 							has_government = fascism
-							has_government = communism
-							has_government = democracy
+							
 						}
 					}
 				}
@@ -2356,7 +2355,7 @@ focus_tree = {
 							OR = {
 								has_government = fascism
 								has_government = communism
-								has_government = democracy
+								
 							}
 						}
 				}
@@ -2372,7 +2371,7 @@ focus_tree = {
 							OR = {
 								has_government = fascism
 								has_government = communism
-								has_government = democracy
+								
 							}
 						}
 				}
@@ -2391,7 +2390,7 @@ focus_tree = {
 						OR = {
 							has_government = fascism
 							has_government = communism
-							has_government = democracy
+							
 						}
 					}
 				}
@@ -2409,7 +2408,7 @@ focus_tree = {
 						OR = {
 							has_government = fascism
 							has_government = communism
-							has_government = democracy
+							
 						}
 					}
 				}
@@ -2427,7 +2426,7 @@ focus_tree = {
 						OR = {
 							has_government = fascism
 							has_government = communism
-							has_government = democracy
+							
 						}
 					}
 				}
@@ -2445,7 +2444,7 @@ focus_tree = {
 						OR = {
 							has_government = fascism
 							has_government = communism
-							has_government = democracy
+							
 						}
 					}
 				}
@@ -2463,7 +2462,7 @@ focus_tree = {
 						OR = {
 							has_government = fascism
 							has_government = communism
-							has_government = democracy
+						
 						}
 					}
 				}
@@ -2479,7 +2478,7 @@ focus_tree = {
 						AND = {
 							PRU = {
 								OR = {
-									has_government = democracy
+									
 									has_government = fascism
 									has_government = communism
 									is_owner_neighbor_of = CHL
@@ -2487,7 +2486,7 @@ focus_tree = {
 							}
 							PAR = {
 								OR = {
-									has_government = democracy
+									
 									has_government = fascism
 									has_government = communism
 									is_owner_neighbor_of = CHL
@@ -2495,7 +2494,7 @@ focus_tree = {
 							}
 							BOL = {
 								OR = {
-									has_government = democracy
+									
 									has_government = fascism
 									has_government = communism
 									is_owner_neighbor_of = CHL
@@ -2503,7 +2502,7 @@ focus_tree = {
 							}
 							ARG = {
 								OR = {
-									has_government = democracy
+									
 									has_government = fascism
 									has_government = communism
 									is_owner_neighbor_of = CHL
@@ -2511,7 +2510,7 @@ focus_tree = {
 							}
 							BRA = {
 								OR = {
-									has_government = democracy
+								
 									has_government = fascism
 									has_government = communism
 									is_owner_neighbor_of = CHL

--- a/common/national_focus/chile.txt
+++ b/common/national_focus/chile.txt
@@ -139,7 +139,7 @@ focus_tree = {
 		icon = GFX_goal_generic_construct_civ_factory
 		x = -5
 		y = 4
-		cost = 10
+		cost = 7
 		
 		ai_will_do = {
 			factor = 10
@@ -275,7 +275,7 @@ focus_tree = {
 		icon = GFX_goal_excavation
 		x = -4
 		y = 2
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHL_establish_corfo }
 
@@ -296,7 +296,7 @@ focus_tree = {
 		icon = GFX_goal_generic_production2
 		x = -3
 		y = 3
-		cost = 10
+		cost = 5
 
 		ai_will_do = {
 			factor = 7
@@ -308,7 +308,7 @@ focus_tree = {
 			add_tech_bonus = {
 				name = CHL_endesa2
 				bonus = 1
-				uses = 2
+				uses = 1
 				category = computing_tech
 			}
 			add_tech_bonus = {
@@ -406,6 +406,12 @@ focus_tree = {
 					instant_build = yes
 				}
 			}
+			add_tech_bonus = {
+				name = CHL_famae_bonus
+				bonus = 1
+				uses = 1
+				category = infantry_weapons
+			}
 		}
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 	}
@@ -477,7 +483,7 @@ focus_tree = {
 			506 = {
 				if = {
 					limit = { is_controlled_by = ROOT }
-					add_extra_state_shared_building_slots = 1
+					add_extra_state_shared_building_slots = 2
 					add_building_construction = {
 						type = industrial_complex
 						level = 1
@@ -488,7 +494,7 @@ focus_tree = {
 			507 = {
 				if = {
 					limit = { is_controlled_by = ROOT }
-					add_extra_state_shared_building_slots = 1
+					add_extra_state_shared_building_slots = 2
 					add_building_construction = {
 						type = industrial_complex
 						level = 1
@@ -498,7 +504,7 @@ focus_tree = {
 			}
 			add_resource = {
 				type = steel
-				amount = 6
+				amount = 8
 				state = 506
 			}
 		}
@@ -581,7 +587,7 @@ focus_tree = {
 		cost = 10
 		relative_position_id = CHL_nuclear_focus
 		available = {
-			num_of_factories > 50
+			
 		}
 
 		prerequisite = { focus = CHL_nuclear_focus focus = CHL_oil_in_the_tierra_del_fuego }
@@ -623,10 +629,10 @@ focus_tree = {
 				state = 507
 			}
 			507 = {
-				add_extra_state_shared_building_slots = 1
+				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = industrial_complex
-					level = 1
+					level = 2
 					instant_build = yes
 				}
 			}
@@ -756,7 +762,7 @@ focus_tree = {
 			add_tech_bonus = {
 				name = CHL_fighter_bonus
 				bonus = 1
-				uses = 1
+				uses = 2
 				category = light_fighter
 			}
 		}
@@ -891,7 +897,7 @@ focus_tree = {
 		icon = GFX_goal_CHL_coa_army
 		x = 7
 		y = 0
-		cost = 10
+		cost = 5
 
 		ai_will_do = {
 			factor = 2
@@ -909,10 +915,10 @@ focus_tree = {
 				add_ideas = limited_conscription
 			}
 		  
-			army_experience = 5
+			army_experience = 25
 			add_doctrine_cost_reduction = {
 				name = CHL_doctrine_bonus
-				cost_reduction = 0.5
+				cost_reduction = 1
 				uses = 1
 				category = land_doctrine
 			}
@@ -1009,7 +1015,7 @@ focus_tree = {
 			}
 			add_doctrine_cost_reduction = {
 				name = CHL_doctrine_bonus
-				cost_reduction = 0.5
+				cost_reduction = 1
 				uses = 1
 				category = land_doctrine
 			}
@@ -1041,7 +1047,7 @@ focus_tree = {
 			}
 			add_doctrine_cost_reduction = {
 				name = CHL_mobile_doctrine
-				cost_reduction = 0.5
+				cost_reduction = 1
 				uses = 1
 				category = land_doctrine
 			}
@@ -1114,7 +1120,7 @@ focus_tree = {
 			add_tech_bonus = {
 				name = infantry_artillery_bonus
 				bonus = 1
-				uses = 1
+				uses = 2
 				category = artillery
 				}
 			}
@@ -1138,7 +1144,7 @@ focus_tree = {
 			add_tech_bonus = {
 				name = infantry_artillery_bonus
 				bonus = 1
-				uses = 1
+				uses = 2
 				category = support_tech
 				}
 			}
@@ -1150,7 +1156,7 @@ focus_tree = {
 		icon = GFX_goal_generic_army_doctrines
 		x = 7
 		y = 3
-		cost = 10
+		cost = 5
 
 		prerequisite = { focus = CHL_artillery_f
 						 focus = CHL_armour_effort
@@ -1164,10 +1170,10 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			army_experience = 10
+			army_experience = 25
 			add_doctrine_cost_reduction = {
 				name = infantry_artillery_bonus
-				cost_reduction = 0.5
+				cost_reduction = 1
 				uses = 1
 				category = land_doctrine
 			}
@@ -1245,16 +1251,16 @@ focus_tree = {
 		completion_reward = {
 			navy_experience = 25
 			279 = {
-				add_extra_state_shared_building_slots = 2
+				add_extra_state_shared_building_slots = 3
 				add_building_construction = {
 					type = dockyard
-					level = 2
+					level = 3
 					instant_build = yes
 				}
 			}
 			add_doctrine_cost_reduction = {
 				name = fleet_in_being_bonus
-				cost_reduction = 0.5
+				cost_reduction = 1
 				uses = 1
 				category = naval_doctrine
 			}
@@ -1429,9 +1435,7 @@ focus_tree = {
 				name = air_bonus
 				bonus = 1
 				uses = 1
-				technology = cv_fighter1
-				technology = cv_fighter2
-				technology = cv_fighter3
+				category = air_equipment
 			}
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH }
@@ -1452,8 +1456,8 @@ focus_tree = {
 
 		available = {	
 			controls_state = 279
-			date > 1937.1.1
-			has_tech = construction1
+			
+			
 		}
 
 		completion_reward = {
@@ -1490,11 +1494,13 @@ focus_tree = {
 		available = {	
 			controls_state = 279
 			controls_state = 507
-			date > 1938.1.1
-			has_tech = construction2
+			
+			
 		}
 
 		completion_reward = {
+			custom_effect_tooltip = available_designer
+			show_ideas_tooltip = CHL_ASMAR_Shipyard
 				279 = {
 					add_extra_state_shared_building_slots = 2
 					add_building_construction = {
@@ -2300,6 +2306,8 @@ focus_tree = {
 						OR = {
 							has_government = fascism
 							has_government = communism
+							has_government = democracy
+						
 						}
 					}
 				}
@@ -2313,8 +2321,9 @@ focus_tree = {
 						}
 						PAR = {
 							OR = {
-								has_government = fascism
-								has_government = communism
+							has_government = fascism
+							has_government = communism
+							has_government = democracy
 							}
 						}
 					}
@@ -2331,6 +2340,7 @@ focus_tree = {
 						OR = {
 							has_government = fascism
 							has_government = communism
+							has_government = democracy
 						}
 					}
 				}
@@ -2346,6 +2356,7 @@ focus_tree = {
 							OR = {
 								has_government = fascism
 								has_government = communism
+								has_government = democracy
 							}
 						}
 				}
@@ -2361,6 +2372,7 @@ focus_tree = {
 							OR = {
 								has_government = fascism
 								has_government = communism
+								has_government = democracy
 							}
 						}
 				}
@@ -2379,6 +2391,7 @@ focus_tree = {
 						OR = {
 							has_government = fascism
 							has_government = communism
+							has_government = democracy
 						}
 					}
 				}
@@ -2396,6 +2409,7 @@ focus_tree = {
 						OR = {
 							has_government = fascism
 							has_government = communism
+							has_government = democracy
 						}
 					}
 				}
@@ -2413,6 +2427,7 @@ focus_tree = {
 						OR = {
 							has_government = fascism
 							has_government = communism
+							has_government = democracy
 						}
 					}
 				}
@@ -2430,6 +2445,7 @@ focus_tree = {
 						OR = {
 							has_government = fascism
 							has_government = communism
+							has_government = democracy
 						}
 					}
 				}
@@ -2447,6 +2463,7 @@ focus_tree = {
 						OR = {
 							has_government = fascism
 							has_government = communism
+							has_government = democracy
 						}
 					}
 				}
@@ -2462,6 +2479,7 @@ focus_tree = {
 						AND = {
 							PRU = {
 								OR = {
+									has_government = democracy
 									has_government = fascism
 									has_government = communism
 									is_owner_neighbor_of = CHL
@@ -2469,6 +2487,7 @@ focus_tree = {
 							}
 							PAR = {
 								OR = {
+									has_government = democracy
 									has_government = fascism
 									has_government = communism
 									is_owner_neighbor_of = CHL
@@ -2476,6 +2495,7 @@ focus_tree = {
 							}
 							BOL = {
 								OR = {
+									has_government = democracy
 									has_government = fascism
 									has_government = communism
 									is_owner_neighbor_of = CHL
@@ -2483,6 +2503,7 @@ focus_tree = {
 							}
 							ARG = {
 								OR = {
+									has_government = democracy
 									has_government = fascism
 									has_government = communism
 									is_owner_neighbor_of = CHL
@@ -2490,6 +2511,7 @@ focus_tree = {
 							}
 							BRA = {
 								OR = {
+									has_government = democracy
 									has_government = fascism
 									has_government = communism
 									is_owner_neighbor_of = CHL

--- a/common/national_focus/colombia.txt
+++ b/common/national_focus/colombia.txt
@@ -1817,7 +1817,7 @@
 		y = 3
 		cost = 10
 		completion_reward = {
-			add_research_slot = 1
+			add_ideas = COL_Reforming_the_Education_Sytem
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH }
 	}
@@ -2312,32 +2312,7 @@
 		search_filters = { FOCUS_FILTER_RESEARCH }
 	}
 	
-	focus = { 
-		id = COL_technology_sharing
-		icon = GFX_goal_research_silver_cooperation
-		prerequisite = { focus = COL_ideological_fanaticism focus = COL_why_we_fight }
-		available = {
-			has_war = yes
-			is_in_faction = yes
-			OR = {
-				num_of_factories > 100
-				any_country = {
-					is_in_faction_with = ROOT
-					num_of_factories > 100
-				}
-			}
-		}
-		x = 23
-		y = 7
-		cost = 10
-		ai_will_do = {
-			factor = 50
-		}
-		completion_reward = {
-			add_research_slot = 1
-		}
-		search_filters = { FOCUS_FILTER_RESEARCH }
-	}
+
 
 
 #air

--- a/common/national_focus/colombia.txt
+++ b/common/national_focus/colombia.txt
@@ -31,7 +31,7 @@
 			COL = { controls_state = 306 }
 		}
 		completion_reward = {
-			army_experience = 5
+			army_experience = 25
 			306 = {
 				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
@@ -124,6 +124,7 @@
 			add_tech_bonus = {
 				name = motorized_bonus
 				bonus = 1
+				uses = 2
 				technology = motorised_infantry
 			}
 		}
@@ -205,13 +206,13 @@
 		icon = GFX_goal_COL_coa_army
 		x = 5
 		y = 0
-		cost = 5
+		cost = 10
 		completion_reward = {
-			army_experience = 10
+			army_experience = 25
 			add_doctrine_cost_reduction = {
 				name = land_doc_bonus
-				cost_reduction = 0.5
-				uses = 1
+				cost_reduction = 1
+				uses = 2
 				category = land_doctrine
 			}
 		}
@@ -230,7 +231,7 @@
 		y = 1
 		cost = 5
 		completion_reward = {
-			army_experience = 5
+			army_experience = 25
 			add_doctrine_cost_reduction = {
 				name = land_doc_bonus
 				cost_reduction = 0.5
@@ -253,7 +254,7 @@
 		y = 3
 		cost = 5
 		completion_reward = {
-			army_experience = 5
+			army_experience = 25
 			add_doctrine_cost_reduction = {
 				name = land_doc_bonus
 				cost_reduction = 0.5
@@ -276,7 +277,7 @@
 		y = 1
 		cost = 10
 		completion_reward = {
-			army_experience = 5
+			army_experience = 25
 			add_tech_bonus = {
 				name = infantry_artillery_bonus
 				bonus = 1
@@ -320,7 +321,7 @@
 		y = 2
 		cost = 10
 		completion_reward = {
-			army_experience = 5	
+			army_experience = 25	
 			
 			hidden_effect = {
 				division_template = { 
@@ -372,7 +373,7 @@
 		prerequisite = { focus = COL_awaite }
 		prerequisite = { focus = COL_explore_amazonia }
 		available = {
-			has_tech = tech_field_hospital			
+						
 		}
 	
 		x = 6
@@ -505,7 +506,7 @@
 		completion_reward = {
 			add_tech_bonus = {
 				name = industrial_bonus
-				bonus = 0.5
+				bonus = 1
 				uses = 1
 				category = industry
 			}
@@ -1232,7 +1233,7 @@
 		prerequisite = { focus = COL_altillanura_ress }
 		
 		available = {
-			num_of_factories > 50
+			
 		}
 		cancel_if_invalid = no
 		x = 8
@@ -2303,7 +2304,7 @@
 			controls_state = 492
 		}
 		completion_reward = {
-			add_research_slot = 1
+			
 			add_state_core = 302
 			add_state_core = 303
 			add_state_core = 492

--- a/common/national_focus/czechoslovakia.txt
+++ b/common/national_focus/czechoslovakia.txt
@@ -24,7 +24,7 @@ focus_tree = {
 		y = 0
 		cost = 5
 
-		ai_will_do = { factor = 1 }
+		ai_will_do = { factor = 99 }
 
 		completion_reward = {
 			custom_effect_tooltip = new_report
@@ -35,7 +35,7 @@ focus_tree = {
 				add_tech_bonus = {
 					name = industrial_bonus
 					bonus = 1
-					uses = 1
+					uses = 2
 					category = industry
 				}
 			}
@@ -50,9 +50,9 @@ focus_tree = {
 
 		x = 0
 		y = 1
-		cost = 5
+		cost = 10
 
-		ai_will_do = {	factor = 0.4 }
+		ai_will_do = {	factor = 99 }
 
 		completion_reward = {
 			custom_effect_tooltip = new_political_advisor
@@ -64,10 +64,10 @@ focus_tree = {
 			#custom_effect_tooltip = CZKE_support_consumer_goods_industry_tooltip_reward
 			effect_tooltip = {
 				75 = {
-					add_extra_state_shared_building_slots = 1
+					add_extra_state_shared_building_slots = 2
 					add_building_construction = {
 						type = industrial_complex
-						level = 1
+						level = 2
 						instant_build = yes
 					}
 				}
@@ -84,12 +84,78 @@ focus_tree = {
 
 		x = 0
 		y = 4
-		cost = 5
+		cost = 10
 
-		ai_will_do = { factor = 0.5 }
+		ai_will_do = { factor = 99 }
 
 		completion_reward = {
 			#custom_effect_tooltip = CZKE_highway_construction_project_tooltip_reward
+			if = {
+				limit = {
+					OR = {
+						AND = {
+							owns_state = 996
+							controls_state = 996
+						}
+						996 = {
+							CONTROLLER = {
+								is_puppet_of = ROOT
+							}
+						}
+					}
+				}
+				996 = {
+					add_building_construction = {
+						type = infrastructure
+						level = 2
+						instant_build = yes
+					}
+				}
+			}
+			if = {
+				limit = {
+					OR = {
+						AND = {
+							owns_state = 664
+							controls_state = 664
+						}
+						664 = {
+							CONTROLLER = {
+								is_puppet_of = ROOT
+							}
+						}
+					}
+				}
+				664 = {
+					add_building_construction = {
+						type = infrastructure
+						level = 2
+						instant_build = yes
+					}
+				}
+			}
+			if = {
+				limit = {
+					OR = {
+						AND = {
+							owns_state = 72
+							controls_state = 72
+						}
+						69 = {
+							CONTROLLER = {
+								is_puppet_of = ROOT
+							}
+						}
+					}
+				}
+				72 = {
+					add_building_construction = {
+						type = infrastructure
+						level = 2
+						instant_build = yes
+					}
+				}
+			}
 			if = {
 				limit = {
 					OR = {
@@ -107,7 +173,7 @@ focus_tree = {
 				69 = {
 					add_building_construction = {
 						type = infrastructure
-						level = 2
+						level = 1
 						instant_build = yes
 					}
 				}
@@ -155,6 +221,28 @@ focus_tree = {
 						instant_build = yes
 					}
 				}
+			}
+			if = {
+				limit = {
+					OR = {
+						AND = {
+							owns_state = 74
+							controls_state = 74
+						}
+						74 = {
+							CONTROLLER = {
+								is_puppet_of = ROOT
+							}
+						}
+					}
+				}
+				74 = {
+					add_building_construction = {
+						type = infrastructure
+						level = 1
+						instant_build = yes
+					}
+				}
 			}							
 			if = {
 				limit = {
@@ -173,7 +261,7 @@ focus_tree = {
 				70 = {
 					add_building_construction = {
 						type = infrastructure
-						level = 3
+						level = 2
 						instant_build = yes
 					}
 				}
@@ -245,6 +333,7 @@ focus_tree = {
 			custom_effect_tooltip = report_reward
 			#custom_effect_tooltip = CZKE_prospect_new_resources_tooltip_reward
 			effect_tooltip = {
+				
 				75 = {
 					add_extra_state_shared_building_slots = 1
 					add_building_construction = {
@@ -339,6 +428,42 @@ focus_tree = {
 				limit = {
 					OR = {
 						AND = {
+							owns_state = 664
+							controls_state = 664
+						}
+						664 = {
+							CONTROLLER = {
+								is_puppet_of = ROOT
+							}
+						}
+					}
+				}
+				664 = {
+					add_extra_state_shared_building_slots = 2
+				} 
+			}
+			if = {
+				limit = {
+					OR = {
+						AND = {
+							owns_state = 996
+							controls_state = 996
+						}
+						996 = {
+							CONTROLLER = {
+								is_puppet_of = ROOT
+							}
+						}
+					}
+				}
+				996 = {
+					add_extra_state_shared_building_slots = 2
+				} 
+			}
+			if = {
+				limit = {
+					OR = {
+						AND = {
 							owns_state = 73
 							controls_state = 73
 						}
@@ -420,7 +545,7 @@ focus_tree = {
 
 		x = 2
 		y = 4
-		cost = 5
+		cost = 10
 
 		ai_will_do = { factor = 0.3 }
 
@@ -430,11 +555,19 @@ focus_tree = {
 			custom_effect_tooltip = report_reward
 			#custom_effect_tooltip = CZKE_chemical_industry_development_tooltip_reward
 			effect_tooltip = {
-				69 = {
-					add_extra_state_shared_building_slots = 1
+				74 = {
+					add_extra_state_shared_building_slots = 2
 					add_building_construction = {
 					type = industrial_complex
-					level = 1
+					level = 2
+					instant_build = yes
+					}
+				}
+				69 = {
+					add_extra_state_shared_building_slots = 2
+					add_building_construction = {
+					type = industrial_complex
+					level = 2
 					instant_build = yes
 					}
 				}
@@ -442,7 +575,7 @@ focus_tree = {
 				add_tech_bonus = {
 					name = synth_bonus
 					bonus = 1
-					uses = 2
+					uses = 1
 					category = synth_resources
 				}
 			}
@@ -490,7 +623,7 @@ focus_tree = {
 
 		x = 4
 		y = 1
-		cost = 5
+		cost = 10
 
 		ai_will_do = {factor = 0.4	}
 
@@ -503,10 +636,10 @@ focus_tree = {
 			#custom_effect_tooltip = CZKE_support_strategic_industry_tooltip_reward
 			effect_tooltip = {
 				9 = {
-					add_extra_state_shared_building_slots = 2
+					add_extra_state_shared_building_slots = 3
 					add_building_construction = {
 						type = arms_factory
-						level = 2
+						level = 3
 						instant_build = yes
 					}
 				}
@@ -1037,7 +1170,7 @@ focus_tree = {
 
 		x = 6
 		y = 4
-		cost = 14.3
+		cost = 5
 
 		ai_will_do = { factor = 0.3	}
 

--- a/common/national_focus/denmark.txt
+++ b/common/national_focus/denmark.txt
@@ -1140,7 +1140,7 @@ focus_tree = {
 	focus = {
 		id = DEN_Popular_Front_against_Fascism
 		icon = GFX_focus_generic_socialist_action
-		cost = 10
+		cost = 5
 		mutually_exclusive = { }
 		ai_will_do = { factor = 0.2 }
 		available = {
@@ -1194,7 +1194,7 @@ focus_tree = {
 	focus = {
 		id = DEN_Channel_Economic_Frustrations
 		icon = GFX_focus_generic_decrease_unemployment
-		cost = 10
+		cost = 5
 		mutually_exclusive = { }
 		ai_will_do = { factor = 5 }
 		available = {
@@ -1281,7 +1281,7 @@ focus_tree = {
 				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = industrial_complex
-					level = 1
+					level = 2
 				}
 			}
 		}
@@ -3527,7 +3527,7 @@ focus_tree = {
 		cost = 10
 		ai_will_do = { factor = 5 }
 		available = {
-			num_of_factories > 60
+			num_of_factories > 50
 		}
 		search_filters = { FOCUS_FILTER_POLITICAL FOCUS_FILTER_RESEARCH FOCUS_FILTER_INDUSTRY }
 		prerequisite = {
@@ -4194,7 +4194,7 @@ focus_tree = {
 	focus = {
 		id = DEN_International_Volunteers
 		icon = GFX_focus_spr_masters_of_our_own_fate
-		cost = 10
+		cost = 5
 		ai_will_do = { factor = 1 }
 		prerequisite = {
 			focus = DEN_Defy_Russia
@@ -4239,15 +4239,15 @@ focus_tree = {
 		available = {
 			OR = {
 				AND = {
-					has_stability > 0.8
+					has_stability > 0.5
 					communism > 0.5
 				}
 				AND = {
 					has_stability > 0.5
-					communism > 0.8
+					communism > 0.5
 				}
-				has_stability > 0.95
-				communism > 0.95
+				has_stability > 0.5
+				communism > 0.5
 			}
 		}
 		search_filters = { FOCUS_FILTER_POLITICAL FOCUS_FILTER_RESEARCH }
@@ -4302,7 +4302,7 @@ focus_tree = {
 	focus = {
 		id = DEN_Pan_Scandinavianism
 		icon = GFX_goal_scandinavianism
-		cost = 10
+		cost = 5
 		search_filters = { FOCUS_FILTER_POLITICAL FOCUS_FILTER_ANNEXATION }
 		ai_will_do = { factor = 1 }
 		prerequisite = {
@@ -5051,7 +5051,7 @@ focus_tree = {
 	focus = {
 		id = DEN_Regional_Economic_Development
 		icon = GFX_goal_FRA_industrial_decentralization
-		cost = 10
+		cost = 5
 		available = {
 			any_controlled_state = {
 				OR = {
@@ -5087,10 +5087,10 @@ focus_tree = {
 						is_core_of = DEN
 					}
 				}
-				add_extra_state_shared_building_slots = 2
+				add_extra_state_shared_building_slots = 3
 				add_building_construction = {
 					type = industrial_complex
-					level = 2
+					level = 3
 					instant_build = yes
 				}
 			}
@@ -6862,10 +6862,10 @@ shared_focus = {
 		add_ideas = den_baltic_trade
 		
 		37 = {
-			add_extra_state_shared_building_slots = 1
+			add_extra_state_shared_building_slots = 3
 			add_building_construction = {
 				type = industrial_complex
-				level = 1
+				level = 3
 				instant_build = yes
 			}
 		}
@@ -7118,6 +7118,7 @@ shared_focus = {
 	y = 2
 	relative_position_id = DEN_Denmark_in_Peril
 	completion_reward = {
+		add_ideas = den_dano_soviet_trade
 		set_variable = {
 			copenhagen_backer = SOV
 		}
@@ -7178,9 +7179,9 @@ shared_focus = {
 					}
 					add_tech_bonus = {
 						name = den_sov_trade_agreement
-						category = cat_medium_armor
+						category = armor
 						uses = 1
-						bonus = 2
+						bonus = 3
 					}
 				}
 			}
@@ -7704,7 +7705,7 @@ shared_focus = {
 shared_focus = {
 	id = DEN_Reestablish_Arms_Industries
 	icon = GFX_goal_generic_construct_mil_factory
-	cost = 5
+	cost = 10
 	search_filters = { FOCUS_FILTER_MILITARY_EQUIPMENT FOCUS_FILTER_INDUSTRY }
 	available_if_capitulated = yes
 	ai_will_do = { 
@@ -7745,10 +7746,10 @@ shared_focus = {
 				controls_state = 99
 			}
 			99 = {
-				add_extra_state_shared_building_slots = 1
+				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = arms_factory
-					level = 1
+					level = 2
 					instant_build = yes
 				}
 			}
@@ -7793,7 +7794,7 @@ shared_focus = {
 		}
 		add_equipment_to_stockpile = {
 			type = infantry_equipment
-			amount = 500
+			amount = 2500
 			producer = DEN
 		}
 	}
@@ -8474,10 +8475,10 @@ shared_focus = {
 			category = artillery
 		}
 		37 = {
-			add_extra_state_shared_building_slots = 1
+			add_extra_state_shared_building_slots = 2
 			add_building_construction = {
 				type = arms_factory
-				level = 1
+				level = 2
 				instant_build = yes
 			}
 		}

--- a/common/national_focus/egypt.txt
+++ b/common/national_focus/egypt.txt
@@ -39,6 +39,7 @@ focus_tree = {
             factor = 10
         }
         completion_reward = {
+            add_political_power = 50
             add_ai_strategy = {
                 type = alliance
                 id = "ENG"
@@ -60,7 +61,7 @@ focus_tree = {
         relative_position_id = EGY_solidify_british_ties
 		x = -4
 		y = 1
-        cost = 10
+        cost = 5
         available = {
             has_country_flag = EGY_fuad_bit_the_dust
             is_subject_of = ENG
@@ -107,7 +108,7 @@ focus_tree = {
             factor = 10
         }
         completion_reward = {
-            add_stability = -0.1
+            add_stability = -0.05
             add_war_support = 0.1
             if = {
                 limit = {
@@ -120,19 +121,19 @@ focus_tree = {
             }
             random_owned_controlled_state = {
                 prioritize = { 447 }
-				add_extra_state_shared_building_slots = 1
+				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = arms_factory
-					level = 1
+					level = 2
 					instant_build = yes
 				}
             }
             random_owned_controlled_state = {
                 prioritize = { 907 }
-				add_extra_state_shared_building_slots = 1
+				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
-					type = arms_factory
-					level = 1
+					type = industrial_complex
+					level = 2
 					instant_build = yes
 				}
             }
@@ -144,7 +145,7 @@ focus_tree = {
         relative_position_id = EGY_empower_govenor_general
 		x = 0
 		y = 2
-        cost = 10
+        cost = 8
         available = {
             is_subject_of = ENG
         }
@@ -218,7 +219,7 @@ focus_tree = {
         relative_position_id = EGY_empower_govenor_general
 		x = 0
 		y = 3
-        cost = 10
+        cost = 8
         available = {
             is_subject_of = ENG
             has_civil_war = no
@@ -265,7 +266,7 @@ focus_tree = {
         relative_position_id = EGY_solidify_british_ties
 		x = -2
 		y = 1
-        cost = 7.2
+        cost = 5
         mutually_exclusive = {
             focus = EGY_empower_govenor_general
         }
@@ -289,7 +290,7 @@ focus_tree = {
                     value = 50
                     localization = EGY_continue_the_status_quo
                 }
-                add_stability = 0.05
+                add_stability = 0.10
             }
             else = {
                 add_political_power = 50
@@ -322,7 +323,7 @@ focus_tree = {
 			}
         }
         completion_reward = {
-            add_political_power = 50
+            add_political_power = 120
             swap_ruler_traits = {
                 remove = EGY_the_young_king
                 add = EGY_the_young_king_2
@@ -335,7 +336,7 @@ focus_tree = {
         relative_position_id = EGY_continue_the_status_quo
 		x = 0
 		y = 2
-        cost = 10
+        cost = 5
         available = {
             has_country_leader = {
                 character = EGY_farouk_i
@@ -372,7 +373,7 @@ focus_tree = {
         relative_position_id = EGY_continue_the_status_quo
 		x = 0
 		y = 3
-        cost = 10
+        cost = 8
         available = {
             compare_autonomy_state > autonomy_puppet
             has_war = no
@@ -409,7 +410,7 @@ focus_tree = {
 		id = EGY_welcome_british_exiles
         text = ENG_welcome_british_exiles
 		icon = GFX_focus_eng_global_defense
-		cost = 10
+		cost = 5
 		relative_position_id = EGY_egypt_serving_the_empire
         x = -1
         y = 1							
@@ -418,9 +419,7 @@ focus_tree = {
 		}
 		available = {
 			is_subject_of = ENG
-            ENG = {
-                has_capitulated = yes
-            }
+            
 		}
         prerequisite = {
 			focus = EGY_egypt_serving_the_empire
@@ -429,19 +428,19 @@ focus_tree = {
 		completion_reward = {
 			add_tech_bonus = {
 				name = CAN_rcaf_station_borden
-				bonus = 0.5
+				bonus = 1
 				uses = 1
 				category = air_doctrine
 			}
 			add_tech_bonus = {
 				name = CAN_army_modernization
-				bonus = 0.5
+				bonus = 1
 				uses = 1
 				category = land_doctrine
 			}			
 			add_tech_bonus = {
 				name = POL_Naval_Officers_School
-				bonus = 0.5
+				bonus = 1
 				uses = 1
 				category = naval_doctrine
 			}
@@ -464,9 +463,7 @@ focus_tree = {
 		}
 		available = {
 			is_subject_of = ENG
-            ENG = {
-                has_capitulated = yes
-            }
+          
 		}
 		completion_reward = {
 			add_manpower = 10000
@@ -480,53 +477,12 @@ focus_tree = {
 		}
         search_filters = {FOCUS_FILTER_MANPOWER FOCUS_FILTER_WAR_SUPPORT FOCUS_FILTER_RESEARCH}
 	}	
+
+				
 	focus = {
-		id = EGY_british_agents
-        text = ENG_british_agents
-		icon = GFX_goal_generic_secret_documents
-		cost = 5
-		prerequisite = {
-			focus = EGY_recruit_volunteers
-		}
-		relative_position_id = EGY_recruit_volunteers
-		x = 0
-		y = 1
-		ai_will_do = {
-			factor = 0.01
-		}
-		allow_branch = {
-			has_dlc = "La Resistance"		
-		}			
-		available = {
-			is_subject_of = ENG
-            ENG = {
-                has_capitulated = yes
-            }
-			has_intelligence_agency = yes	
-		}
-		completion_reward = {
-			create_operative_leader = {
-				bypass_recruitment = yes
-				nationalities = { ENG }
-				portrait_tag_override = ENG
-			}
-			create_operative_leader = {
-				bypass_recruitment = yes
-				nationalities = { ENG WLS }
-				portrait_tag_override = ENG
-			}
-			create_operative_leader = {
-				bypass_recruitment = yes
-				nationalities = { ENG }
-				portrait_tag_override = ENG
-			}											
-		}
-		search_filters = { FOCUS_FILTER_ESPIONAGE }
-	}
-	focus = {
-		id = EGY_landing_exercices
-        text = ENG_landing_exercices
-		icon = GFX_goal_generic_amphibious_assault
+		id = EGY_Embrace_English_Leadership
+        text = EGY_Embrace_English_Leadership
+		icon = GFX_focus_generic_treaty
 		cost = 10
 		prerequisite = {
 			focus = EGY_welcome_british_exiles
@@ -537,84 +493,16 @@ focus_tree = {
 		ai_will_do = {
 			factor = 10
 		}
-		available = {
-            is_subject_of = ENG
-            ENG = {
-                has_capitulated = yes
-            }
-			has_navy_size = {
-			    size > 5
-			}
-			has_army_manpower = {
-				size > 49999
-			}			
-		}
-
-		completion_reward = {
-			add_tech_bonus = {
-				name = uk_amphibious_focus
-				bonus = 1.0
-				uses = 1
-				category = marine_tech
-				category = r56_special_forces_training_tech 
-			}
-			add_tech_bonus = {
-				name = uk_amphibious_focus
-				bonus = 1.0
-				uses = 1
-				category = tp_tech
-			}
-			if = {
-				limit = {
-					has_dlc = "Man the Guns"
-				}
-				add_tech_bonus = {
-					name = JAP_expand_the_snlf
-					bonus = 1
-					uses = 1
-					category = amphibious_armor_tech
-				}				
-			}									
-		}
-		search_filters = { FOCUS_FILTER_RESEARCH }
-	}			
-	focus = {
-		id = EGY_reclaim_the_british_isles_exile
-        text = ENG_reclaim_the_british_isles_exile
-		icon = GFX_focus_attack_britain
-		cost = 10
-		prerequisite = {
-			focus = EGY_landing_exercices
-		}
-		relative_position_id = EGY_landing_exercices
-		x = 0
-		y = 1
-		ai_will_do = {
-			factor = 10
-		}
 		will_lead_to_war_with = ENG
 		available = {
-            NOT = {
-                has_government = communism
-            }
-			has_navy_size = {
-			    size > 15
-			}
-			has_army_manpower = {
-				size > 119999
-			}
-			has_capitulated = no
-			r56_script_i_am_sane = yes
-			ENG = {
-				r56_script_target_is_sane = yes
-			}				
+			
 		}
 		completion_reward = {
-			create_wargoal = {
-				type = topple_government
-				target = ENG
-				expire = 0
-			}									
+            add_ideas = EGY_British_Acceptance	
+            ENG = { country_event = egypt.67 }
+
+				
+            						
 		}
 		search_filters = { FOCUS_FILTER_ANNEXATION }
 	}
@@ -762,25 +650,25 @@ focus_tree = {
                 }
                 add_building_construction = {
 					type = bunker
-					level = 1
+					level = 2
 					instant_build = yes
 					province = 7188
                 }
                 add_building_construction = {
 					type = bunker
-					level = 1
+					level = 2
 					instant_build = yes
 					province = 4143
                 }
                 add_building_construction = {
 					type = bunker
-					level = 1
+					level = 2
 					instant_build = yes
 					province = 12004
                 }
                 add_building_construction = {
 					type = bunker
-					level = 1
+					level = 2
 					instant_build = yes
 					province = 10005
                 }
@@ -802,7 +690,7 @@ focus_tree = {
             factor = 10
         }
         completion_reward = {
-            air_experience = 10
+            air_experience = 25
             random_owned_controlled_state = {
                 prioritize = { 447 }
 				add_building_construction = {
@@ -812,7 +700,7 @@ focus_tree = {
 				}
 				add_building_construction = {
 					type = anti_air_building
-					level = 1
+					level = 2
 					instant_build = yes
 				}
 			}
@@ -825,7 +713,7 @@ focus_tree = {
 				}
                 add_building_construction = {
 					type = anti_air_building
-					level = 1
+					level = 2
 					instant_build = yes
 				}
 			}
@@ -857,8 +745,8 @@ focus_tree = {
 					province = 4076
                 }
                 add_building_construction = {
-					type = coastal_bunker
-					level = 1
+					type = bunker
+					level = 2
 					instant_build = yes
 					province = 4076
                 }
@@ -871,27 +759,27 @@ focus_tree = {
 					province = 10005
                 }
                 add_building_construction = {
-					type = coastal_bunker
-					level = 1
+					type = bunker
+					level = 2
 					instant_build = yes
 					province = 10005
                 }
             }
             random_owned_controlled_state = {
                 prioritize = { 907 }
-                add_extra_state_shared_building_slots = 1
+                add_extra_state_shared_building_slots = 2
                 add_building_construction = {
                     type = infrastructure
-                    level = 1
+                    level = 2
                     instant_build = yes
                 }
             }
             random_owned_controlled_state = {
                 prioritize = { 447 }
-                add_extra_state_shared_building_slots = 1
+                add_extra_state_shared_building_slots = 2
                 add_building_construction = {
                     type = infrastructure
-                    level = 1
+                    level = 2
                     instant_build = yes
                 }
             }
@@ -921,7 +809,7 @@ focus_tree = {
             factor = 10
         }
         completion_reward = {
-            air_experience = 10
+            air_experience = 25
             add_ideas = ENG_joint_air_training_scheme
 
         }
@@ -946,12 +834,12 @@ focus_tree = {
         completion_reward = {
             add_equipment_to_stockpile = {
                 type = convoy
-                amount = 100
+                amount = 250
                 producer = EGY
             }
             random_owned_controlled_state = {
                 prioritize = { 447 }
-				add_extra_state_shared_building_slots = 1
+				add_extra_state_shared_building_slots = 3
 				add_building_construction = {
 					type = dockyard
 					level = 1
@@ -1029,7 +917,7 @@ focus_tree = {
         relative_position_id = EGY_commonwealth_research_cooperation
 		x = 1
 		y = 1
-        cost = 7.2
+        cost = 6
         prerequisite = {
             focus = EGY_commonwealth_research_cooperation
         }
@@ -1040,7 +928,7 @@ focus_tree = {
         completion_reward = {
 			add_equipment_to_stockpile = {
 				type = infantry_equipment
-  				amount = 3000
+  				amount = 1500
  		 		producer = ENG
 			}
 			add_opinion_modifier = { target = ENG modifier = RAJ_Weapon_Shipments }
@@ -1089,7 +977,7 @@ focus_tree = {
                 name = EGY_study_british_armor
 				bonus = 1
 				uses = 1
-				category = cat_medium_armor
+				category = armor
 			}
         }
     }
@@ -1099,7 +987,7 @@ focus_tree = {
         relative_position_id = EGY_commonwealth_research_cooperation
 		x = -3
 		y = 4
-        cost = 10
+        cost = 8
         prerequisite = {
             focus = EGY_study_british_armor
         }
@@ -1114,7 +1002,7 @@ focus_tree = {
             factor = 10
         }
         completion_reward = {
-            add_stability = 0.05
+            add_stability = 0.10
             if = {
                 limit = {
                     has_full_control_of_state = 447
@@ -1140,7 +1028,7 @@ focus_tree = {
         cost = 10
         available = {
             is_in_faction = yes
-            has_war = yes
+            
         }
         prerequisite = {
             focus = EGY_study_british_armor
@@ -6149,7 +6037,7 @@ focus_tree = {
             add_tech_bonus = {
 				bonus = 1
 				uses = 1
-				category = steel_tech
+				category = aluminium_tech
 			}
             random_owned_controlled_state = {
                 limit = {
@@ -6239,7 +6127,7 @@ focus_tree = {
         relative_position_id = EGY_banque_misr
 		x = 1
 		y = 1
-        cost = 5
+        cost = 10
         prerequisite = {
             focus = EGY_banque_misr
         }
@@ -6300,7 +6188,7 @@ focus_tree = {
         relative_position_id = EGY_banque_misr
 		x = -1
 		y = 1
-        cost = 5
+        cost = 10
         prerequisite = {
             focus = EGY_banque_misr
         }
@@ -6399,7 +6287,7 @@ focus_tree = {
         relative_position_id = EGY_development_in_sudan
 		x = 1
 		y = 1
-        cost = 5
+        cost = 10
         prerequisite = {
             focus = EGY_development_in_sudan
             focus = EGY_banha_industrial_sectors
@@ -6612,17 +6500,9 @@ focus_tree = {
 		y = 1
         cost = 5
         available = {
-            has_civil_war = no
-			controls_state = 453
+          
 		}
-        bypass = {
-            OR = {
-                has_capitulated = yes
-                NOT = {
-                    controls_state = 453
-                }
-            }
-        }
+       
         prerequisite = {
             focus = EGY_expand_the_defence_department
         }
@@ -6635,19 +6515,19 @@ focus_tree = {
                 add_building_construction = {
 					type = bunker
 					province = 4161
-					level = 1
+					level = 2
 					instant_build = yes
 				}
 				add_building_construction = {
 					type = bunker
 					province = 10002
-					level = 1
+					level = 2
 					instant_build = yes
 				}
                 add_building_construction = {
 					type = bunker
 					province = 12073
-					level = 1
+					level = 2
 					instant_build = yes
 				}
 			}
@@ -6709,13 +6589,8 @@ focus_tree = {
         relative_position_id = EGY_defence_of_cairo
 		x = 0
 		y = 1
-        cost = 10
-        available = {
-            OR = {
-			    has_capitulated = yes
-                surrender_progress > 0.6
-            }
-		}
+        cost = 8
+        
         prerequisite = {
             focus = EGY_defence_of_cairo
         }
@@ -6734,7 +6609,7 @@ focus_tree = {
 		y = 1
         cost = 10
         available = {
-			has_capitulated = yes
+			
 		}
         prerequisite = {
             focus = EGY_organize_the_egyptian_resistance
@@ -6755,7 +6630,7 @@ focus_tree = {
 		y = 1
         cost = 10
         available = {
-			has_capitulated = yes
+			
 		}
         prerequisite = {
             focus = EGY_organize_the_egyptian_resistance
@@ -6769,7 +6644,7 @@ focus_tree = {
             add_manpower = 5000
             add_equipment_to_stockpile = {
 				type = infantry_equipment
-  				amount = 3000
+  				amount = 2000
  		 		producer = EGY
 			}
             add_offsite_building = { type = arms_factory level = 2 }
@@ -6781,9 +6656,9 @@ focus_tree = {
         relative_position_id = EGY_the_army_in_exile
 		x = -1
 		y = 1
-        cost = 10
+        cost = 5
         available = {
-			has_capitulated = yes
+			
 		}
         prerequisite = {
             focus = EGY_the_army_in_exile
@@ -6805,7 +6680,7 @@ focus_tree = {
 		y = 1
         cost = 10
         available = {
-			has_capitulated = yes
+			
 		}
         prerequisite = {
             focus = EGY_the_army_in_exile
@@ -6816,13 +6691,13 @@ focus_tree = {
         }
         completion_reward = {
             air_experience = 25
-            add_manpower = 1000
+            add_manpower = 3000
             add_equipment_to_stockpile = {
                 type = fighter_equipment
-                amount = 50
+                amount = 200
                 producer = EGY
             }
-            add_offsite_building = { type = arms_factory level = 1 }
+           
         }
     }
 	focus = {
@@ -6841,10 +6716,10 @@ focus_tree = {
             add_to_variable = { EGY_the_egyptian_land_doctrine_cost_factor = -0.1 }
             add_to_variable = { EGY_the_egyptian_army_command_power_gain_mult = 0.1 }
             custom_effect_tooltip = EGY_egyptian_military_academy_tt
-			army_experience = 10
+			army_experience = 25
             add_tech_bonus = {
                 name = EGY_egyptian_military_academy
-				bonus = 0.5
+				bonus = 1
 				uses = 1
 				category = land_doctrine
 			}
@@ -6881,7 +6756,7 @@ focus_tree = {
         relative_position_id = EGY_egyptian_military_academy
 		x = 1
 		y = 1
-        cost = 10
+        cost = 5
 		available = {
 			any_owned_state = {
                 is_core_of = SUD
@@ -6962,7 +6837,7 @@ focus_tree = {
 			add_tech_bonus = {
                 name = EGY_field_piece_research
                 bonus = 1
-                uses = 1
+                uses = 2
                 category = artillery
             }
 
@@ -7001,7 +6876,7 @@ focus_tree = {
         relative_position_id = EGY_modernize_our_weaponary
 		x = 2
 		y = 1
-        cost = 10
+        cost = 5
 		prerequisite = {
 			focus = EGY_modernize_our_weaponary
 		}
@@ -7026,7 +6901,7 @@ focus_tree = {
         relative_position_id = EGY_radio_technologies
 		x = 0
 		y = 1
-        cost = 10
+        cost = 8
 		prerequisite = {
 			focus = EGY_radio_technologies
 		}
@@ -7038,7 +6913,7 @@ focus_tree = {
             add_to_variable = { EGY_the_egyptian_army_military_leader_cost_factor = -0.5 }
             add_to_variable = { EGY_the_egyptian_land_doctrine_cost_factor = -0.1 }
             custom_effect_tooltip = EGY_egyptian_military_academy_tt
-			army_experience = 10
+			army_experience = 25
             add_tech_bonus = {
                 name = EGY_new_military_institute
 				bonus = 0.5
@@ -7075,14 +6950,7 @@ focus_tree = {
                 create_intelligence_agency = yes				
             }	
             add_ideas = GER_abwehr_contacts
-            create_operative_leader = {
-                name = "Zakaria Mohieddin"
-                GFX = GFX_EGY_Portrait_Zakaria_Mohieddin
-                traits = { operative_well_groomed }
-                bypass_recruitment = yes
-                available_to_spy_master = no
-                nationalities = { EGY }
-            }
+            
 
         }
     }
@@ -7164,7 +7032,7 @@ focus_tree = {
         relative_position_id = EGY_radio_technologies
 		x = -1
 		y = 2
-        cost = 7.2
+        cost = 8
 		prerequisite = {
 			focus = EGY_logistical_brigades
 		}
@@ -7282,7 +7150,7 @@ focus_tree = {
 				bonus = 1
 				ahead_reduction = 1
 				uses = 1
-				category = r56_desert_infantry_tech
+				category = r56_special_forces_training_tech
 			}
         }
     }
@@ -7320,7 +7188,7 @@ focus_tree = {
         relative_position_id = EGY_egyptian_military_academy
         x = 7
         y = 0
-        cost = 10
+        cost = 5
         search_filters = {FOCUS_FILTER_RESEARCH FOCUS_FILTER_NAVY_XP}
         ai_will_do = {
             factor = 10
@@ -7330,7 +7198,7 @@ focus_tree = {
             add_doctrine_cost_reduction = {
                 name = EGY_expand_the_navy
                 uses = 2
-                cost_reduction = 0.5
+                cost_reduction = 1
                 category = naval_doctrine
             }
         }
@@ -7383,7 +7251,7 @@ focus_tree = {
 		y = 3
         cost = 5
 		available = {
-            is_subject = no
+            
 			has_full_control_of_state = 907
             NOT = {
                 OR = {
@@ -7485,7 +7353,7 @@ focus_tree = {
         relative_position_id = EGY_expand_alexandria_shipping
         x = 0
         y = 1
-        cost = 5
+        cost = 10
         available = { 
             has_full_control_of_state = 551 
         }
@@ -7498,15 +7366,15 @@ focus_tree = {
         }
         completion_reward = {
             551 = {
-				add_extra_state_shared_building_slots = 1
+				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = dockyard
-					level = 1
+					level = 2
 				    instant_build = yes
 			    }
                 add_building_construction = {
                     type = naval_base
-                    level = 2
+                    level = 1
                     instant_build = yes
                     province = 12725
                 }
@@ -7560,7 +7428,7 @@ focus_tree = {
         relative_position_id = EGY_expand_the_navy
         x = -3
         y = 1
-        cost = 7.2
+        cost = 7
         prerequisite = {
             focus = EGY_expand_the_navy
         }
@@ -7583,7 +7451,7 @@ focus_tree = {
         relative_position_id = EGY_el_saka_forces
         x = 0
         y = 1
-        cost = 10
+        cost = 5
         prerequisite = {
             focus = EGY_el_saka_forces
         }
@@ -7607,7 +7475,7 @@ focus_tree = {
         relative_position_id = EGY_expand_the_navy
         x = -1
         y = 1
-        cost = 7.2
+        cost = 10
         prerequisite = {
             focus = EGY_expand_the_navy
         }
@@ -7642,7 +7510,7 @@ focus_tree = {
         relative_position_id = EGY_expand_the_navy
         x = 1
         y = 1
-        cost = 7.2
+        cost = 10
         prerequisite = {
             focus = EGY_expand_the_navy
         }
@@ -7738,7 +7606,7 @@ focus_tree = {
         relative_position_id = EGY_big_farouq
         x = 1
         y = 1
-        cost = 7.2
+        cost = 10
         prerequisite = {
             focus = EGY_big_farouq
             focus = EGY_carrier_development
@@ -7777,7 +7645,7 @@ focus_tree = {
         cost = 10
         available = { 
             has_navy_size = {
-                size > 29
+                size > 14
             }
             any_owned_state = { 
                 is_coastal = yes 
@@ -7914,7 +7782,7 @@ focus_tree = {
         relative_position_id = EGY_expand_the_navy
         x = 6
         y = 0
-        cost = 10
+        cost = 5
         search_filters = {FOCUS_FILTER_AIR_XP FOCUS_FILTER_RESEARCH}
         ai_will_do = {
             factor = 10
@@ -7924,7 +7792,7 @@ focus_tree = {
             add_doctrine_cost_reduction = {
                 name = EGY_reestablish_control_of_the_EAAF
                 uses = 1
-                cost_reduction = 0.5
+                cost_reduction = 1
                 category = air_doctrine
             }
 
@@ -7936,7 +7804,7 @@ focus_tree = {
         relative_position_id = EGY_reestablish_control_of_the_EAAF
         x = -1
         y = 1
-        cost = 7.2
+        cost = 7
         prerequisite = {
             focus = EGY_reestablish_control_of_the_EAAF
         }
@@ -7969,7 +7837,7 @@ focus_tree = {
         relative_position_id = EGY_reestablish_control_of_the_EAAF
         x = 1
         y = 1
-        cost = 7.2
+        cost = 10
         prerequisite = {
             focus = EGY_reestablish_control_of_the_EAAF
         }
@@ -8000,7 +7868,7 @@ focus_tree = {
         relative_position_id = EGY_reestablish_control_of_the_EAAF
         x = 2
         y = 2
-        cost = 5
+        cost = 8
         available = {
             ENG = {
                 exists = yes
@@ -8019,7 +7887,7 @@ focus_tree = {
         completion_reward = {
             add_equipment_to_stockpile = {
                 type = fighter_equipment
-                amount = 40
+                amount = 150
                 producer = ENG
             }
         }
@@ -8043,11 +7911,12 @@ focus_tree = {
         }
         completion_reward = {
             air_experience = 25
-            add_doctrine_cost_reduction = {
-                name = EGY_royal_egyptian_airforce
+            
+            add_tech_bonus = {
+                name = EGY_victor_taits_legacy
+                bonus = 1
                 uses = 1
-                cost_reduction = 0.5
-                category = air_doctrine
+                category = air_equipment
             }
         }
     }
@@ -8057,7 +7926,7 @@ focus_tree = {
         relative_position_id = EGY_reestablish_control_of_the_EAAF
         x = -1
         y = 3
-        cost = 7.2
+        cost = 10
         prerequisite = {
             focus = EGY_royal_egyptian_airforce
         }
@@ -8070,7 +7939,7 @@ focus_tree = {
                 name = EGY_bomber_production
                 bonus = 1
                 uses = 1
-                category = tactical_bomber
+                category = medium_air
             }
         }
     }
@@ -8104,7 +7973,7 @@ focus_tree = {
         relative_position_id = EGY_royal_egyptian_airforce
         x = 0
         y = 2
-        cost = 7.2
+        cost = 5
         prerequisite = {
             focus = EGY_royal_egyptian_airforce
         }
@@ -8113,8 +7982,8 @@ focus_tree = {
             factor = 10
         }
         completion_reward = {
-            air_experience = 5
-            navy_experience = 5
+            air_experience = 25
+            navy_experience = 25
             add_tech_bonus = {
                 name = EGY_radar_defence_technologies
                 bonus = 1

--- a/common/national_focus/estonia.txt
+++ b/common/national_focus/estonia.txt
@@ -206,10 +206,10 @@ focus_tree = {
 						}
 					}
 				}
-				add_extra_state_shared_building_slots = 1
+				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = industrial_complex
-					level = 1
+					level = 2
 					instant_build = yes
 				}
 			}
@@ -309,9 +309,9 @@ focus_tree = {
 		}
 
 		available = {
-			communism < 0.01
-			fascism < 0.05
-			democratic > 0.25
+			
+			
+			democratic > 0.30
 		}
 
 		search_filters = { FOCUS_FILTER_POLITICAL }
@@ -357,7 +357,7 @@ focus_tree = {
 		}
 
 		available = {
-			democratic < 0.1
+			neutrality > 0.6
 		}
 
 		search_filters = { FOCUS_FILTER_POLITICAL FOCUS_FILTER_STABILITY FOCUS_FILTER_WAR_SUPPORT }
@@ -795,8 +795,7 @@ focus_tree = {
 		}
 
 		available = {
-			NOT = { has_idea = civilian_economy }
-			NOT = { has_idea = low_economic_mobilisation }
+			
 		}
 
 		search_filters = { FOCUS_FILTER_INDUSTRY }
@@ -2341,13 +2340,13 @@ focus_tree = {
 				limit = {
 					has_DLC = "Man the Guns"
 				}
-				has_capitulated = yes
+				
 			}
 			if = {
 				limit = {
 					NOT = { has_DLC = "Man the Guns" }
 				}
-				surrender_progress > 0.5
+				
 			}
 		}
 		available_if_capitulated = yes
@@ -2399,13 +2398,13 @@ focus_tree = {
 				limit = {
 					has_DLC = "Man the Guns"
 				}
-				has_capitulated = yes
+				
 			}
 			if = {
 				limit = {
 					NOT = { has_DLC = "Man the Guns" }
 				}
-				surrender_progress > 0.5
+				
 			}
 		}
 		available_if_capitulated = yes
@@ -2435,11 +2434,11 @@ focus_tree = {
 			OR = {
 				AND = {
 					has_DLC = "Man the Guns"
-					has_capitulated = yes
+					
 				}
 				AND = {
 					NOT = { has_DLC = "Man the Guns" }
-					surrender_progress > 0.5
+					
 				}
 			}
 		}
@@ -2471,7 +2470,7 @@ focus_tree = {
 	focus = {
 		id = EST_baltic_economic_union
 		icon = GFX_goal_generic_consumer_goods
-		prerequisite = { focus = EST_formalize_baltic_entente }
+		
 		prerequisite = { focus = EST_break_the_silence }
 		x = -2
 		y = 1
@@ -2484,7 +2483,7 @@ focus_tree = {
 		}
 
 		available = {
-			is_faction_leader = yes
+			
 		}
 
 		search_filters = { FOCUS_FILTER_POLITICAL FOCUS_FILTER_INDUSTRY }
@@ -2517,7 +2516,7 @@ focus_tree = {
 		}
 
 		available = {
-			is_faction_leader = yes
+			
 		}
 
 		search_filters = { FOCUS_FILTER_POLITICAL FOCUS_FILTER_INDUSTRY }
@@ -2550,7 +2549,7 @@ focus_tree = {
 		}
 
 		available = {
-			is_faction_leader = yes
+			
 		}
 
 		search_filters = { FOCUS_FILTER_POLITICAL FOCUS_FILTER_INDUSTRY }
@@ -2589,7 +2588,7 @@ focus_tree = {
 		}
 
 		available = {
-			is_faction_leader = yes
+			
 		}
 
 		search_filters = { FOCUS_FILTER_POLITICAL FOCUS_FILTER_MANPOWER FOCUS_FILTER_INDUSTRY }
@@ -2630,7 +2629,7 @@ focus_tree = {
 		}
 
 		available = {
-			is_faction_leader = yes
+			
 		}
 
 		search_filters = { FOCUS_FILTER_POLITICAL FOCUS_FILTER_MANPOWER FOCUS_FILTER_INDUSTRY }
@@ -2767,54 +2766,30 @@ focus_tree = {
 		}
 
 		available = {
-			is_faction_leader = yes
+			
 		}
 
 		search_filters = { FOCUS_FILTER_POLITICAL FOCUS_FILTER_ANNEXATION }
 		completion_reward = {
-			every_other_country = {
-				limit = {
-					is_baltic_state = yes
-					is_in_faction_with = ROOT
-				}
-				country_event = {
-					id = BALTIC_entente_events.6
-					days = 3
-				}
-			}
-			effect_tooltip = {
-				if = {
-					limit = {
-						any_other_country = {
-							is_baltic_state = yes
-							is_in_faction_with = ROOT
-						}
-					}
-					custom_effect_tooltip = if_they_accept_tt
-					every_other_country = {
-						limit = {
-							is_baltic_state = yes
-							is_in_faction_with = ROOT
-						}
-					}
-					custom_effect_tooltip = annex_countries_tt
-				}
-			}
-			every_other_country = {
-				limit = {
-					is_baltic_state = yes
-					NOT = {
-						is_in_faction_with = ROOT
-					}
-				}
-				custom_effect_tooltip = gain_annex_tt
-				hidden_effect = {
-					create_wargoal = {
-						target = PREV
-						type = annex_everything
-					}
-				}
-			}
+			LAT = {
+				country_event = { id = est.19 days = 1 }
+            }
+			LIT = {
+				country_event = { id = est.19 days = 1 }
+            }
+			# Latvia
+			12 = { add_core_of = ROOT }
+			810 = { add_core_of = ROOT }
+			809 = { add_core_of = ROOT }
+			808 = { add_core_of = ROOT }
+			190 = { add_core_of = ROOT }
+
+			#Lithuania
+			815 = { add_core_of = ROOT }
+			189 = { add_core_of = ROOT }
+			188 = { add_core_of = ROOT }
+			11 = { add_core_of = ROOT }
+			814 = { add_core_of = ROOT }
 		}
 	}
 	

--- a/common/national_focus/finland.txt
+++ b/common/national_focus/finland.txt
@@ -17,14 +17,15 @@ focus_tree = {
 	focus = {
 		id = fin_political_focus
 		icon = GFX_focus_fin_political_focus
-		cost = 5
+		cost = 10
 		x = 18
 		y = 0
 		
 		available_if_capitulated = yes
 		
 			completion_reward = {
-					add_political_power = 75
+					add_political_power = 100
+					
 				}
 				search_filters = { FOCUS_FILTER_POLITICAL }
 
@@ -43,7 +44,7 @@ focus_tree = {
 			army_experience = 25
 			add_doctrine_cost_reduction = {
 				name = land_doc_bonus
-				cost_reduction = 0.5
+				cost_reduction = 1
 				uses = 2
 				category = land_doctrine
 			}
@@ -325,7 +326,7 @@ focus_tree = {
 	focus = {
 		id = fin_neutralfoc
 		icon = GFX_goal_generic_generic_political
-		cost = 5
+		cost = 10
 		prerequisite = {
 			focus = fin_individual_freedom
 		}
@@ -796,26 +797,26 @@ focus_tree = {
 			add_ideas = FIN_stopai
 			add_equipment_to_stockpile = {
 				type = infantry_equipment_1 
-				amount = 1000 
+				amount = 3000 
 				producer = GER 
 			}
 			add_equipment_to_stockpile = {
 				type = support_equipment_1 
-				amount = 250 
+				amount = 1000
 				producer = GER 
 			}
 			add_equipment_to_stockpile = {
 				type = artillery_equipment_1 
-				amount = 100 
+				amount = 450
 				producer = GER 
 			}
 			add_equipment_to_stockpile = {
 				type = motorized_equipment
-				amount = 25
+				amount = 100
 				producer = GER
 			}
 			hidden_effect = {
-				add_manpower = 10000
+				add_manpower = 30000
 				load_oob = "FIN_GER"
 			}
 		}	
@@ -2830,11 +2831,7 @@ focus_tree = {
 		available_if_capitulated = yes
 		
 		available = {
-			OR = {
-				has_defensive_war = yes
-				threat > 0.55
 			
-			}
 		}
 		
 		completion_reward = {
@@ -3738,7 +3735,13 @@ focus_tree = {
 		}
 		
 		completion_reward ={
-			
+			add_tech_bonus = {
+				
+				name = Finish_Module_Bonus
+				bonus = 0.5
+				uses = 2
+				category = air_equipment
+				}
 			custom_effect_tooltip = HOL_fokkers
 
 			if = {
@@ -3747,13 +3750,13 @@ focus_tree = {
 	            }
 	            add_equipment_to_stockpile = {
 	                type = small_plane_airframe_1
-	                amount = 100
+	                amount = 250
 	                producer = HOL
 	            }
 	            else = {
 	                add_equipment_to_stockpile = {
 	                    type = small_plane_airframe_0
-	                    amount = 100
+	                    amount = 250
 	                    producer = HOL
 					}   
 				}
@@ -4567,19 +4570,20 @@ focus_tree = {
 			focus = fin_realtionsfoc
 		}
 		available = {
-			NOT = { has_war_with = SWE }
-			SWE = { exists = yes }
-			NOT = {
-				has_idea = FIN_revenge
-			}
+			
+			
+			
 		}
 		relative_position_id = fin_realtionsfoc
 		x = 0
 		y = 1
 
 		completion_reward = { 
-			give_guarantee = SWE
-			SWE = { give_guarantee = FIN }
+			set_rule = { can_create_factions = yes }
+			create_faction = nordic_defence_alliance
+			SWE = { country_event = { id = finland.18 } }
+			add_ideas = fin_Finnish_Swedish_Defense_Pact
+			SWE = { add_ideas = fin_Finnish_Swedish_Defense_Pact }
 		}
 	}
 	
@@ -4589,7 +4593,7 @@ focus_tree = {
 		icon = GFX_goal_generic_position_armies
 		cost = 10
 		prerequisite = {
-			focus = fin_mutualdefpactfoc
+			focus = fin_mutualdefpactfoc foucs = fin_negroid
 		}
 		available = {
 			DEN = { has_war_with = GER }
@@ -4597,8 +4601,8 @@ focus_tree = {
 			SWE = { exists = yes }
 		}
 		relative_position_id = fin_mutualdefpactfoc
-		x = 1
-		y = 1
+		x = 0
+		y = 2
 		
 		completion_reward = { 
 				custom_effect_tooltip = fin_interventiontooltip
@@ -4799,7 +4803,7 @@ focus_tree = {
 					}
 				}
 			
-				# Norway
+			# Norway
 				110 = { add_core_of = ROOT }
 				142 = { add_core_of = ROOT }
 				143 = { add_core_of = ROOT }
@@ -4823,14 +4827,17 @@ focus_tree = {
 				964 = { add_core_of = ROOT }
 				337 = { add_core_of = ROOT } #Faroe islands
 
-				#Denmark claimed Greenland and Iceland, why not claim them for ourselves?
+			# Denmark claimed Greenland and Iceland, why not claim them for ourselves?
 				100 = { add_claim_by = ROOT }
 				101 = { add_claim_by = ROOT }
 		
 				news_event = { id = wtt_news.53 hours = 6 }
 				set_global_flag = form_scandinavia_flag
-			
-				add_ideas = SCA_united				
+			    
+				add_ideas = SCA_united	
+				add_ideas = generic_recent_army_unification
+				add_ideas = generic_recent_economic_unification
+				add_ideas = generic_recent_political_unification			
 			}
 		}
 			search_filters = { FOCUS_FILTER_ANNEXATION FOCUS_FILTER_STABILITY FOCUS_FILTER_POLITICAL }
@@ -5113,11 +5120,55 @@ focus_tree = {
 		completion_reward = {
 				add_ideas = fin_sweadvisors
 				SWE = { add_ideas = swe_finadvisors }
+				add_tech_bonus = {
+					ahead_reduction = 1
+					name = Fin-Swe_military_bonus
+					bonus = 1
+					uses = 1
+					category = armor
+					category = infantry_weapons
+					category = artillery
+				}
 		
 		}
 
 	}
-	
+	focus = {
+		id = fin_Scandinavian_Industrial_Boom
+		text = fin_swefinmilfoc
+		icon = GFX_goal_SWE_FIN_coa_royal
+		cost = 10
+		prerequisite = {
+			focus = fin_mutualdefpactfoc
+		}
+		relative_position_id = fin_mutualdefpactfoc
+		x = 1
+		y = 1
+		
+		available_if_capitulated = yes
+		
+		completion_reward = {
+			add_tech_bonus = {
+				ahead_reduction = 1
+				name = Fin-Swe_industry_bonus
+				bonus = 1
+				uses = 1
+				category = industry
+				
+			}	
+			add_ideas = fin_Finnish_Swedish_Industrial_Pact
+			SWE = { add_ideas = fin_Finnish_Swedish_Industrial_Pact }
+			SWE = { add_tech_bonus = {
+				ahead_reduction = 1
+				name = Fin-Swe_industry_bonus
+				bonus = 1
+				uses = 1
+				category = industry
+				}
+			}
+		}
+
+	}
 	focus = {
 		id = fin_nordicom
 		text = fin_nordicom

--- a/common/national_focus/greece.txt
+++ b/common/national_focus/greece.txt
@@ -524,7 +524,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = GRE_the_anatolian_refugees
 		will_lead_to_war_with = TUR
-		cost = 20
+		cost = 10
 		ai_will_do = {
 			base = 1
 		}
@@ -3763,7 +3763,7 @@ focus_tree = {
 						country_exists = TUR
 						TUR = { has_opinion = { target = GRE value > 70 } } 
 					}
-					add_offsite_building = { type = industrial_complex level = 2 }
+					add_offsite_building = { type = industrial_complex level = 3 }
 				}
 				if = { 	
 					limit = { 

--- a/common/national_focus/honduras.txt
+++ b/common/national_focus/honduras.txt
@@ -22,7 +22,7 @@ focus = {
 		icon = GFX_goal_generic_small_arms
 		x = 41
 		y = 0
-		cost = 10
+		cost = 5
 		
 		ai_will_do = {
 			factor = 10
@@ -36,7 +36,7 @@ focus = {
 		available_if_capitulated = yes
 
 		completion_reward = {
-			army_experience = 30
+			army_experience = 25
 		}
 }
 	
@@ -105,7 +105,7 @@ focus = {
 		completion_reward = {
 			add_tech_bonus = {
 				name = infantry_weapons_bonus
-				bonus = 0.75
+				bonus = 1
 				uses = 2
 				category = infantry_weapons
 			}
@@ -162,11 +162,11 @@ focus = {
 		available_if_capitulated = yes
 
 		completion_reward = {
-			army_experience = 20
+			army_experience = 25
 			add_tech_bonus = {
 				name = infantry_artillery_bonus
-				bonus = 0.3
-				uses = 3
+				bonus = 1
+				uses = 2
 				category = support_tech
 			}
 		}
@@ -301,7 +301,7 @@ focus = {
 		prerequisite = { focus = HON_special_forces }
 		x = 40
 		y = 3
-		cost = 10
+		cost = 5
 		
 		ai_will_do = {
 			factor = 10
@@ -419,10 +419,11 @@ focus = {
 		available_if_capitulated = yes
 
 		completion_reward = {
+			army_experience = 25
 			add_doctrine_cost_reduction = {
 				name = land_doc_bonus
-				cost_reduction = 0.5
-				uses = 1
+				cost_reduction = 1
+				uses = 2
 				category = land_doctrine
 			}
 		}
@@ -447,7 +448,7 @@ focus = {
 			add_tech_bonus = {
 				name = land_doc_bonus
 				bonus = 1
-				uses = 1
+				uses = 2
 				technology = etax_army_focus
 				technology = etax_army_firepower
 				technology = etax_army_defense
@@ -473,10 +474,10 @@ focus = {
 		available_if_capitulated = yes
 
 		completion_reward = {
-			army_experience = 5
+			army_experience = 25
 			add_doctrine_cost_reduction = {
 				name = land_doc_bonus
-				cost_reduction = 0.5
+				cost_reduction = 1
 				uses = 2
 				category = land_doctrine
 			}
@@ -882,10 +883,10 @@ focus = {
 		completion_reward = {
 			add_tech_bonus = {
 				name = fighter_bonus
-				bonus = 1
+				bonus = 0.5
 				uses = 2
-				category = light_fighter
-				category = cat_heavy_fighter
+				category = air_equipment
+				
 			}
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH }
@@ -913,7 +914,7 @@ focus = {
 			add_tech_bonus = {
 				name = bomber_bonus
 				bonus = 1
-				uses = 2
+				uses = 1
 				
 				category = tactical_bomber
 			}
@@ -934,10 +935,11 @@ focus = {
 		available_if_capitulated = yes
 		
 		completion_reward = {
+			air_experience = 45
 			add_doctrine_cost_reduction = {
 				name = air_doc_bonus
-				cost_reduction = 0.5
-				uses = 3
+				cost_reduction = 1
+				uses = 1
 				category = air_doctrine
 			}
 		}
@@ -987,7 +989,7 @@ focus = {
 			}
 		}
 		completion_reward = {
-			add_political_power = 100
+			add_political_power = 150
 		}
 		search_filters = { FOCUS_FILTER_POLITICAL }
 	}
@@ -1002,7 +1004,7 @@ focus = {
 		relative_position_id = HON_politics
 		x = -10
 		y = 1
-		cost = 10
+		cost = 7
 		ai_will_do = {
 			factor = 10
 			modifier = {
@@ -1095,12 +1097,12 @@ focus = {
 		}
 		x = 1
 		y = 1
-		cost = 10
+		cost = 7
 		ai_will_do = {
 			factor = 9.9
 		}
 		completion_reward = {
-			army_experience = 5
+			army_experience = 25
 			add_ideas = GEN_Organise_Youth_Fas_I
 		}
 		search_filters = {  FOCUS_FILTER_MANPOWER }
@@ -1203,12 +1205,12 @@ focus = {
 		relative_position_id = HON_united_fruit_coup
 		x = -1
 		y = 1
-		cost = 5
+		cost = 10
 		ai_will_do = {
 			factor = 15
 		}
 		completion_reward = {
-			add_equipment_to_stockpile = { type = infantry_equipment_0 amount = 1000 producer = USA }
+			add_equipment_to_stockpile = { type = infantry_equipment_0 amount = 2500 producer = USA }
 		}
 		search_filters = { FOCUS_FILTER_MILITARY_EQUIPMENT }
 	}
@@ -1224,7 +1226,7 @@ focus = {
 			factor = 15
 		}
 		completion_reward = {
-			army_experience = 10
+			army_experience = 25
 			add_ideas = militarism_focus
 		}
 		search_filters = {  FOCUS_FILTER_MANPOWER }
@@ -1252,7 +1254,7 @@ focus = {
 		relative_position_id = HON_american_arms
 		x = 1
 		y = 1
-		cost = 5
+		cost = 8
 		ai_will_do = {
 			factor = 15
 		}
@@ -1303,7 +1305,7 @@ focus = {
 			factor = 10
 			modifier = {
 				factor = 2
-				strength_ratio = { tag = ELS ratio > 1.5 }
+				strength_ratio = { tag = ELS ratio > 0.5 }
 			}
 			modifier = {
 				factor = 0.1
@@ -1360,7 +1362,7 @@ focus = {
 			factor = 10
 			modifier = {
 				factor = 2
-				strength_ratio = { tag = NIC ratio > 1.5 }
+				strength_ratio = { tag = NIC ratio > 0.5 }
 			}
 			modifier = {
 				factor = 0.1
@@ -1426,7 +1428,7 @@ focus = {
 			factor = 10
 			modifier = {
 				factor = 2
-				strength_ratio = { tag = GUA ratio > 1.5 }
+				strength_ratio = { tag = GUA ratio > 0.5 }
 			}
 			modifier = {
 				factor = 0.1
@@ -1494,7 +1496,7 @@ focus = {
 			factor = 10
 			modifier = {
 				factor = 2
-				strength_ratio = { tag = COS ratio > 1.5 }
+				strength_ratio = { tag = COS ratio > 0.5 }
 			}
 			modifier = {
 				factor = .1
@@ -1556,7 +1558,7 @@ focus = {
 						controls_state = 311 
 					}
 				}
-				ENG = { has_opinion = { target = ROOT value > 59 }  controls_state = 311  }
+				ENG = { has_opinion = { target = ROOT value > 49 }  controls_state = 311  }
 			}
 			if = {
 				limit = {
@@ -1564,10 +1566,10 @@ focus = {
 						controls_state = 311 
 					}
 				}
-				MEX = { has_opinion = { target = ROOT value > 59 }  controls_state = 311 }
+				MEX = { has_opinion = { target = ROOT value > 49 }  controls_state = 311 }
 			}
 			ROOT = {
-				has_equipment = { convoy > 99 }
+				has_equipment = { convoy > 49 }
 			}
 		}
 		prerequisite = { focus = HON_take_guatemala }
@@ -1617,7 +1619,7 @@ focus = {
 			factor = 10
 			modifier = {
 				factor = 4
-				strength_ratio = { tag = "PAN" ratio > 1.5 }
+				strength_ratio = { tag = "PAN" ratio > 0.5 }
 			}
 			modifier = {
 				factor = .1
@@ -1681,10 +1683,10 @@ focus = {
 			ROOT = {
 				controls_state = 316
 			}
-			USA = { has_opinion = { target = ROOT value > 59 } 
+			USA = { has_opinion = { target = ROOT value > 49 } 
 			controls_state = 685
 			}
-			 has_equipment = { convoy > 100 }
+			 has_equipment = { convoy > 49 }
 		}
 		prerequisite = { focus = HON_take_costa_rica }
 		relative_position_id = HON_take_costa_rica
@@ -1723,8 +1725,8 @@ focus = {
 		}
 		completion_reward = {
 			swap_ideas = { remove_idea = HON_better_banana_republic add_idea = HON_best_banana_republic }
-			random_owned_controlled_state = { add_building_construction = { type = infrastructure level = 1 instant_build = yes } }
-			random_owned_controlled_state = { add_building_construction = { type = infrastructure level = 1 instant_build = yes } }
+			random_owned_controlled_state = { add_building_construction = { type = infrastructure level = 2 instant_build = yes } }
+			random_owned_controlled_state = { add_building_construction = { type = infrastructure level = 2 instant_build = yes } }
 			build_railway = {
 				path = { 8017 12865 2031 }
 			}
@@ -1787,10 +1789,10 @@ focus = {
 							include_locked = yes
 						}
 					}
-					add_extra_state_shared_building_slots = 1
+					add_extra_state_shared_building_slots = 2
 					add_building_construction = {
 						type = dockyard
-						level = 1
+						level = 2
 						instant_build = yes
 					}
 				}
@@ -1839,10 +1841,10 @@ focus = {
 							include_locked = yes
 						}
 					}
-					add_extra_state_shared_building_slots = 1
+					add_extra_state_shared_building_slots = 2
 					add_building_construction = {
 						type = dockyard
-						level = 1
+						level = 2
 						instant_build = yes
 					}
 				}
@@ -2481,7 +2483,7 @@ focus = {
 			factor = 15
 		}
 		completion_reward = {
-		add_political_power = 25
+		add_political_power = 100
 		SOV = {
 				add_opinion_modifier = { target = HON modifier = HON_soviet_assist }
 				}
@@ -2517,10 +2519,10 @@ focus = {
 		completion_reward = {
 		
 		random_owned_controlled_state = { 
-		add_extra_state_shared_building_slots = 2
+		add_extra_state_shared_building_slots = 3
 		add_building_construction = {
 					type = industrial_complex
-					level = 2
+					level = 3
 					instant_build = yes
 				}} 
 			}
@@ -2979,7 +2981,7 @@ focus = {
 		prerequisite = { focus = HON_land_reform}
 		x = 14
 		y = 6
-		cost = 10
+		cost = 7
 		ai_will_do = {
 			factor = 10
 		}
@@ -3019,7 +3021,7 @@ focus = {
 		prerequisite = { focus = HON_collective_agriculture }
 		x = 14
 		y = 7
-		cost = 10
+		cost = 7
 		ai_will_do = {
 			factor = 10
 		}
@@ -3070,7 +3072,7 @@ focus = {
 		}
 		x = 13
 		y = 8
-		cost = 10
+		cost = 5
 		
 		completion_reward = {
 			set_rule = { can_create_factions = yes }
@@ -3093,7 +3095,7 @@ focus = {
 		}
 		x = 15
 		y = 8
-		cost = 10
+		cost = 5
 		ai_will_do = {
 			factor = 10
 			modifier = {
@@ -3942,7 +3944,7 @@ focus = {
 			}
 		}
 		completion_reward = {
-		add_political_power = 120
+		add_political_power = 150
 		}
 		search_filters = { FOCUS_FILTER_POLITICAL }
 	}
@@ -3952,14 +3954,15 @@ focus = {
 		prerequisite = { focus =  HON_status_quo}
 		x = 20
 		y = 2
-		cost = 10
+		cost = 5
 		ai_will_do = {
 			base = 10	
 		}
 		completion_reward = {
+			army_experience = 25
 			add_doctrine_cost_reduction = {
 				name = air_doc_bonus
-				cost_reduction = 0.5
+				cost_reduction = 1
 				uses = 1
 				category = air_doctrine
 			}
@@ -3986,7 +3989,7 @@ focus = {
 		prerequisite = {focus = HON_stabilize_economy}
 		x = 20
 		y = 4
-		cost = 10
+		cost = 5
 		ai_will_do = {
 			base = 10	
 		}
@@ -4020,6 +4023,13 @@ focus = {
 			base = 10	
 		}
 		completion_reward = {
+			random_owned_controlled_state = { 
+				add_extra_state_shared_building_slots = 2
+					add_building_construction = {
+						type = industrial_complex
+						level = 2
+						instant_build = yes
+					} }
 				add_tech_bonus = {
 					name = industrial_bonus
 					bonus = 1
@@ -4073,7 +4083,7 @@ focus = {
 		}		
 		x = 20
 		y = 7
-		cost = 10
+		cost = 5
 		ai_will_do = {
 			base = 10	
 		}
@@ -4088,7 +4098,7 @@ focus = {
 		prerequisite = {focus = HON_join_allies}
 		x = 19
 		y = 8
-		cost = 7.2
+		cost = 5
 		ai_will_do = {
 			base = 10	
 		}
@@ -4116,7 +4126,7 @@ focus = {
 		completion_reward = {
 			add_doctrine_cost_reduction = {
 				name = naval_doc_bonus
-				cost_reduction = 0.5
+				cost_reduction = 1
 				uses = 2
 				category = naval_doctrine
 			}
@@ -4178,11 +4188,11 @@ focus = {
 		completion_reward = {
 			add_tech_bonus = {
 				name = HON_build_infra1
-				bonus = 0.5
+				bonus = 1
 				uses = 1
 				category = construction_tech
 			}
-			random_owned_controlled_state = { add_building_construction = { type = infrastructure level = 1 instant_build = yes } }
+			random_owned_controlled_state = { add_building_construction = { type = infrastructure level = 2 instant_build = yes } }
 		}
 	}
 	focus = {
@@ -4593,12 +4603,12 @@ focus = {
 		prerequisite = { focus = HON_monarchist_coup}
 		x = 24
 		y = 4
-		cost = 5
+		cost = 10
 		ai_will_do = {
 			factor = 10
 		}
 		completion_reward = {
-			add_equipment_to_stockpile = { type = infantry_equipment_0 amount = 1000 producer = SPR }
+			add_equipment_to_stockpile = { type = infantry_equipment_0 amount = 2500 producer = SPR }
 		}
 		search_filters = { FOCUS_FILTER_MILITARY_EQUIPMENT }
 	}
@@ -4614,7 +4624,7 @@ focus = {
 		}
 		completion_reward = {
 			add_ideas = militarism_focus
-			army_experience = 10
+			army_experience = 25
 		}
 		search_filters = {  FOCUS_FILTER_MANPOWER }
 	}

--- a/common/national_focus/hungary.txt
+++ b/common/national_focus/hungary.txt
@@ -5097,7 +5097,7 @@ focus_tree = {
 		x = 37
 		y = 0
 
-		cost = 5
+		cost = 10
 
 		ai_will_do = {
 			factor = 90
@@ -5323,22 +5323,24 @@ focus_tree = {
 		x = 1
 		y = 2
 		relative_position_id = HUN_industrial_revitalization
-		cost = 5
+		cost = 10
 
 		ai_will_do = {
 			factor = 90
 		}
 
 		completion_reward = {
+			
 			43 = {
-				add_extra_state_shared_building_slots = 2
+				add_extra_state_shared_building_slots = 3
+				add_building_construction = {
+					type = industrial_complex
+					level = 1
+					instant_build = yes
+				}
 			}
-			155 = {
-				add_extra_state_shared_building_slots = 2
-			}
-			154 = {
-				add_extra_state_shared_building_slots = 2
-			}
+			
+			
 		}
 		
 		search_filters = { FOCUS_FILTER_INDUSTRY }
@@ -5375,7 +5377,7 @@ focus_tree = {
 		y = 4
 		relative_position_id = HUN_industrial_revitalization
 
-		cost = 5
+		cost = 10
 
 		ai_will_do = {
 			factor = 90
@@ -5458,7 +5460,7 @@ focus_tree = {
 		y = 2
 		relative_position_id = HUN_civilian_industry
 
-		cost = 5
+		cost = 10
 
 		ai_will_do = {
 			factor = 70

--- a/common/national_focus/indonesia.txt
+++ b/common/national_focus/indonesia.txt
@@ -32,10 +32,10 @@ focus = {
 	cost = 5 
 	available_if_capitulated = yes 
 	completion_reward = {
-		army_experience = 15
+		army_experience = 25
 		add_doctrine_cost_reduction = {
 			name = land_doc_bonus
-			cost_reduction = 0.25
+			cost_reduction = 1
 			uses = 1
 			category = land_doctrine
 		}
@@ -53,7 +53,7 @@ focus = {
 	x = 1
 	y = 1
 	prerequisite = { focus = INS_koninklijk_nederlands_indisch_leger }
-	cost = 10 
+	cost = 5 
 	available_if_capitulated = yes 
 	completion_reward = {
 		set_rule = { can_send_volunteers = yes }
@@ -76,7 +76,7 @@ focus = {
 	cost = 10
 	available_if_capitulated = yes 
 	completion_reward = {
-		add_manpower = 1000
+		add_manpower = 5000
 		swap_ideas = {
 			remove_idea = INS_army_idea
 			add_idea = INS_army_idea_two
@@ -101,7 +101,7 @@ focus = {
 	available = {
 
 	}
-	cost = 10 
+	cost = 5 
 	available_if_capitulated = yes 
 	completion_reward = {
 			
@@ -500,13 +500,13 @@ focus = {
 	}
 	x = 4
 	y = 0
-	cost = 10 
+	cost = 5
 	available_if_capitulated = yes 
 	completion_reward = {
-		air_experience = 10	
+		air_experience = 45
 		add_doctrine_cost_reduction = {
 			name = air_doc_bonus
-			cost_reduction = 0.5
+			cost_reduction = 1
 			uses = 1
 			category = air_doctrine	
 		}
@@ -540,10 +540,9 @@ focus = {
 		add_tech_bonus = {
 			name = air_doc_bonus
 			bonus = 1
-			uses = 2
-			category = light_air
-			category = medium_air
-			category = heavy_air
+			uses = 1
+			category = air_equipment
+			
 		}		
 	}
 	search_filters = { FOCUS_FILTER_RESEARCH }
@@ -572,7 +571,7 @@ focus = {
 		        limit = { is_controlled_by = ROOT }
 		        add_building_construction = {
 		            type = air_base
-		            level = 1
+		            level = 3
 		            instant_build = yes
 		        }
 		    }
@@ -582,7 +581,7 @@ focus = {
 		        limit = { is_controlled_by = ROOT }
 		        add_building_construction = {
 		            type = air_base
-		            level = 1
+		            level = 3
 		            instant_build = yes
 		        }
 		    }
@@ -592,7 +591,7 @@ focus = {
 		        limit = { is_controlled_by = ROOT }
 		        add_building_construction = {
 		            type = air_base
-		            level = 1
+		            level = 3
 		            instant_build = yes
 		        }
 		    }
@@ -602,7 +601,7 @@ focus = {
 		        limit = { is_controlled_by = ROOT }
 		        add_building_construction = {
 		            type = air_base
-		            level = 1
+		            level = 3
 		            instant_build = yes
 		        }
 		    }
@@ -612,7 +611,7 @@ focus = {
 		        limit = { is_controlled_by = ROOT }
 		        add_building_construction = {
 		            type = air_base
-		            level = 1
+		            level = 3
 		            instant_build = yes
 		        }
 		    }
@@ -622,7 +621,7 @@ focus = {
 		        limit = { is_controlled_by = ROOT }
 		        add_building_construction = {
 		            type = air_base
-		            level = 1
+		            level = 3
 		            instant_build = yes
 		        }
 		    }
@@ -632,7 +631,7 @@ focus = {
 		        limit = { is_controlled_by = ROOT }
 		        add_building_construction = {
 		            type = air_base
-		            level = 1
+		            level = 3
 		            instant_build = yes
 		        }
 		    }
@@ -642,7 +641,7 @@ focus = {
 		        limit = { is_controlled_by = ROOT }
 		        add_building_construction = {
 		            type = air_base
-		            level = 1
+		            level = 3
 		            instant_build = yes
 		        }
 		    }
@@ -742,7 +741,7 @@ focus = {
 	cost = 10 
 	available_if_capitulated = yes 
 	completion_reward = {
-		navy_experience = 10
+		navy_experience = 25
 		random_owned_controlled_state = {
 			prioritize = { 976 }
 			limit = {
@@ -884,13 +883,13 @@ focus = {
 	y = 2
 	relative_position_id = INS_naval_autonomy
 	prerequisite = { focus = INS_java_shipyards }
-	cost = 10 
+	cost = 7 
 	available_if_capitulated = yes 
 	completion_reward = {
 		add_tech_bonus = {
 			name = GER_landing_craft
 			bonus = 1
-			uses = 1
+			uses = 2
 			category = tp_tech
 		}
 	}
@@ -1115,7 +1114,7 @@ focus = {
 	x =13
 	y =0
 	available = {
-		num_of_factories > 15
+		num_of_factories > 9
 	}
 	cost = 10 
 	available_if_capitulated = yes 
@@ -1167,7 +1166,7 @@ focus = {
 	mutually_exclusive = { }
 	prerequisite = { focus = INS_phillips_radio }
 	available = { INS = { is_subject_of = HOL } }
-	cost = 10 
+	cost = 5
 	available_if_capitulated = yes 
 	completion_reward = {
 		add_to_tech_sharing_group = netherlands_research
@@ -1296,7 +1295,7 @@ focus = {
 	    667 = {
 			if = {
 				limit = { is_controlled_by = ROOT }
-				add_extra_state_shared_building_slots = 1
+				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = industrial_complex
 					level = 1
@@ -1448,10 +1447,10 @@ focus = {
 		976 = {
 			if = {
 				limit = { is_controlled_by = ROOT }
-				add_extra_state_shared_building_slots = 1
+				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = arms_factory
-					level = 1
+					level = 2
 					instant_build = yes
 				}
 	        }
@@ -1498,7 +1497,7 @@ focus = {
 				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = industrial_complex
-					level = 1
+					level = 2
 					instant_build = yes
 				}
 	        }
@@ -1511,7 +1510,7 @@ focus = {
 				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = industrial_complex
-					level = 1
+					level = 2
 					instant_build = yes
 				}
 	        }
@@ -1618,7 +1617,7 @@ focus = {
 		976 = {
 			if = {
 				limit = { is_controlled_by = ROOT }
-				add_extra_state_shared_building_slots = 4
+				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = arms_factory
 					level = 1
@@ -1647,12 +1646,12 @@ focus = {
 	completion_reward = {
 		add_resource = {
 			type = oil
-			amount = 4
+			amount = 5
 			state = 976
 		}
 		add_resource = {
 			type = steel
-			amount = 8
+			amount = 10
 			state = 976
 		}
 	}

--- a/common/national_focus/italy.txt
+++ b/common/national_focus/italy.txt
@@ -3220,11 +3220,11 @@ focus_tree = {
 		id = ITA_steel_industry_in_terni
 		icon = GFX_goal_generic_light_industry
 		prerequisite = { focus = ITA_italian_highways_bba }
-		mutually_exclusive = { focus = ITA_power_plants_in_terni }
+		
 		x = -1
 		y = 1
 		relative_position_id = ITA_italian_highways_bba
-		cost = 5
+		cost = 10
 		available = {
 			has_full_control_of_state = 2
 		}
@@ -3235,15 +3235,15 @@ focus_tree = {
 			add_to_variable = { ITA_iri_production_speed_arms_factory_factor = 0.05 }
 			custom_effect_tooltip = ITA_steel_industry_in_terni_ricostruzione_industriale_tt
 			2 = {
-				add_extra_state_shared_building_slots = 2
+				add_extra_state_shared_building_slots = 4
 				add_building_construction = {
 					type = arms_factory
-					level = 2
+					level = 4
 					instant_build = yes
 				}
 				add_resource = {
 					type = steel
-					amount = 8
+					amount = 16
 				}
 			}
 		}
@@ -3253,11 +3253,11 @@ focus_tree = {
 		id = ITA_power_plants_in_terni
 		icon = GFX_goal_generic_construct_civ_factory
 		prerequisite = { focus = ITA_italian_highways_bba }
-		mutually_exclusive = { focus = ITA_steel_industry_in_terni }
+		
 		x = 1
 		y = 1
 		relative_position_id = ITA_italian_highways_bba
-		cost = 5
+		cost = 10
 		available = {
 			has_full_control_of_state = 2
 		}
@@ -3269,10 +3269,10 @@ focus_tree = {
 			custom_effect_tooltip = ITA_power_plants_in_terni_ricostruzione_industriale_tt
 
 			2 = {
-				add_extra_state_shared_building_slots = 2
+				add_extra_state_shared_building_slots = 4
 				add_building_construction = {
 					type = industrial_complex
-					level = 2
+					level = 4
 					instant_build = yes
 				}
 			}
@@ -3287,9 +3287,9 @@ focus_tree = {
 		x = 1
 		y = 1
 		relative_position_id = ITA_steel_industry_in_terni
-		cost = 5
+		cost = 8
 		available = {
-			has_tech = synth_oil_experiments
+			
 		}
 
 		search_filters = {FOCUS_FILTER_INDUSTRY FOCUS_FILTER_RESEARCH}
@@ -3297,15 +3297,15 @@ focus_tree = {
 		completion_reward = {
 			add_tech_bonus = {
 				name = ITA_finance_anic
-				bonus = 0.75
+				bonus = 1
 				uses = 2
 				category = cat_synth_oil
 			}
 			2 = {
-				add_extra_state_shared_building_slots = 1
+				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = synthetic_refinery
-					level = 1
+					level = 2
 					instant_build = yes
 				}
 			}

--- a/common/national_focus/mexico.txt
+++ b/common/national_focus/mexico.txt
@@ -563,12 +563,14 @@ focus_tree = {
 						state = 478
 						state = 277
 						state = 477
+						state = 931
+						state = 932
 					}
 				}
-				add_extra_state_shared_building_slots = 2
+				add_extra_state_shared_building_slots = 1
 				add_building_construction = {
 					type = industrial_complex
-					level = 2
+					level = 1
 					instant_build = yes
 				}
 			}
@@ -631,7 +633,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = MEX_focus_end_land_reform
 
-		cost = 10
+		cost = 15
 
 		ai_will_do = {
 			factor = 100
@@ -640,18 +642,7 @@ focus_tree = {
 		search_filters = {FOCUS_FILTER_STABILITY FOCUS_FILTER_MEX_CAUDILLO_REBELLION}
 		completion_reward = {
 			every_state = {
-				limit = {
-					OR = {
-						state = 277
-						state = 477
-						state = 485
-						state = 478
-						state = 479
-						state = 480
-						state = 932
-						state = 931
-					}
-				}
+				
 				add_extra_state_shared_building_slots = 1
 			}
 			MEX_decrease_cedillo_tension = yes
@@ -3131,6 +3122,8 @@ focus_tree = {
 						state = 277
 						state = 479
 						state = 477
+						state = 932
+						state = 931
 					}
 				}
 				add_extra_state_shared_building_slots = 1
@@ -4654,18 +4647,11 @@ focus_tree = {
 			factor = 100
 			modifier = {
 				factor = 0.1
-				has_stability < 0.75
+				has_stability < 0.60
 			}			
 		}
 
-		available = {
-			is_subject = no
-			r56_script_i_am_sane = yes
-			OR = {
-				has_government = fascism
-				has_government = communism
-			}
-		}
+		
 
 
 		

--- a/common/national_focus/netherlands.txt
+++ b/common/national_focus/netherlands.txt
@@ -40,7 +40,7 @@ focus_tree = {
         completion_reward = {
         	random_owned_controlled_state = {
 				prioritize = { 7 }
-				add_extra_state_shared_building_slots = 1
+				
 				limit = {
 					free_building_slots = {
 						building = infrastructure
@@ -63,11 +63,24 @@ focus_tree = {
 				}
 				add_building_construction = {
 					type = infrastructure
-					level = 1
+					level = 2
 					instant_build = yes
 				}
 			}
-
+			random_owned_controlled_state = {
+				prioritize = { 36 }
+				limit = {
+					free_building_slots = {
+						building = infrastructure
+						size > 0
+					}
+				}
+				add_building_construction = {
+					type = infrastructure
+					level = 3
+					instant_build = yes
+				}
+			}
 			if = {
 				limit = {
 					has_idea = tblra_recovery_from_the_great_depression1
@@ -127,7 +140,7 @@ focus_tree = {
 			add_tech_bonus = {
 				name = industrial_bonus
 				bonus = 1
-				uses = 1
+				uses = 2
 				category = industry
 			}
 			if = {
@@ -325,16 +338,7 @@ focus_tree = {
 		available_if_capitulated = yes
 
 		available = {
-			NOT = {
-				OR = {
-					has_idea = tblra_recovery_from_the_great_depression1
-					has_idea = tblra_recovery_from_the_great_depression2
-					has_idea = tblra_recovery_from_the_great_depression3
-					has_idea = tblra_recovery_from_the_great_depression4
-					has_idea = tblra_recovery_from_the_great_depression5
-				}
-				has_idea = HOL_reliance_on_the_gold_standard
-			}
+			
 		}
 
 		ai_will_do = {
@@ -372,10 +376,42 @@ focus_tree = {
 						include_locked = yes
 					}
 				}
-				add_extra_state_shared_building_slots = 1
+				add_extra_state_shared_building_slots = 4
 				add_building_construction = {
 					type = industrial_complex
-					level = 1
+					level = 4
+					instant_build = yes
+				}
+			}
+			random_owned_controlled_state = {
+				prioritize = { 36 }
+				limit = {
+					free_building_slots = {
+						building = industrial_complex
+						size > 0
+						include_locked = yes
+					}
+				}
+				add_extra_state_shared_building_slots = 4
+				add_building_construction = {
+					type = industrial_complex
+					level = 4
+					instant_build = yes
+				}
+			}
+			random_owned_controlled_state = {
+				prioritize = { 7 }
+				limit = {
+					free_building_slots = {
+						building = industrial_complex
+						size > 0
+						include_locked = yes
+					}
+				}
+				add_extra_state_shared_building_slots = 4
+				add_building_construction = {
+					type = industrial_complex
+					level = 4
 					instant_build = yes
 				}
 			}
@@ -446,10 +482,10 @@ focus_tree = {
         }
         completion_reward = {
             695 = {
-                add_extra_state_shared_building_slots = 2
+                add_extra_state_shared_building_slots = 3
                 add_building_construction = {
                     type = synthetic_refinery
-                    level = 1
+                    level = 2
                     instant_build = yes
 				}
 				add_building_construction = {
@@ -472,11 +508,11 @@ focus_tree = {
 					}
 				}
 			}
-          #  add_resource = {
-          #      type = rubber
-          #      amount = 2
-          #      state = 695
-          #  }
+            add_resource = {
+                type = rubber
+                amount = 2
+                state = 695
+            }
 			add_tech_bonus = {
 				name = GER_coal_liquidization
 				bonus = 1.0
@@ -513,12 +549,22 @@ focus_tree = {
 			factor = 2
 		}
         available = {
-            has_tech = excavation3
-			date > 1942.02.01
-			controls_state = 36
-		}
+			OR = {
+				controls_state = 6
+				BEL = {
+					is_puppet_of = ROOT				
+				}
+			}
+			OR = {
+				controls_state = 8
+				LUX = {
+					is_puppet_of = ROOT				
+				}
+			}
+        }
         completion_reward = {
-			36 = {
+			every_state = {
+				
 				add_extra_state_shared_building_slots = 2
 			}
         }

--- a/common/national_focus/norway.txt
+++ b/common/national_focus/norway.txt
@@ -42,7 +42,7 @@ focus_tree = {
 		icon = GFX_goal_NOR_fish
 		x = 0
 		y = 0
-		cost = 5
+		cost = 10
 		ai_will_do = {
 			base = 10
 		}
@@ -57,10 +57,10 @@ focus_tree = {
 		completion_reward = {
 			random_owned_controlled_state = {
 				prioritize = { 144 }
-				add_extra_state_shared_building_slots = 1
+				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = industrial_complex
-					level = 1
+					level = 2
 					instant_build = yes
 				}
 			}
@@ -229,7 +229,7 @@ focus_tree = {
 			}
 			add_doctrine_cost_reduction = {
 				name = naval_doc_bonus
-				cost_reduction = 0.5
+				cost_reduction = 1
 				uses = 1
 				category = naval_doctrine
 			}
@@ -1094,21 +1094,16 @@ focus_tree = {
 		completion_reward = {
 			add_doctrine_cost_reduction = {
 				name = air_doc_bonus
-				cost_reduction = 0.5
+				cost_reduction = 1
 				uses = 2
 				category = air_doctrine
 			}
 			add_tech_bonus = {
 				name = NOR_bomber_plane_bonus
 				bonus = 1.0
-				ahead_reduction = 1
 				uses = 2
-				category = cas_bomber
-				category = naval_bomber
-				category = tactical_bomber
-				technology = med_maritime1 ### R56 bonuses only!
-				technology = med_maritime2
-				technology = med_maritime3
+				category = air_equipment
+				
 			}
 			random_owned_controlled_state = {
 				prioritize = { 110 }
@@ -1141,7 +1136,7 @@ focus_tree = {
 		icon = GFX_goal_NOR_coa_army
 		x = 14
 		y = 0
-		cost = 5
+		cost = 10
 		ai_will_do = {
 			factor = 10
 			modifier = {
@@ -1154,15 +1149,15 @@ focus_tree = {
 		}
 		
 		completion_reward = {
-			add_equipment_to_stockpile = { type = infantry_equipment_0 amount = 200 producer = NOR }
-			add_equipment_to_stockpile = { type = support_equipment_1 amount = 20 producer = NOR }
+			add_equipment_to_stockpile = { type = infantry_equipment_0 amount = 500 producer = NOR }
+			add_equipment_to_stockpile = { type = support_equipment_1 amount = 100 producer = NOR }
 			add_doctrine_cost_reduction = {
 				name = land_doc_bonus
-				cost_reduction = 0.5
+				cost_reduction = 1
 				uses = 2
 				category = land_doctrine
 			}
-			army_experience = 15
+			army_experience = 25
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH FOCUS_FILTER_ARMY_XP }
 	}
@@ -1186,8 +1181,8 @@ focus_tree = {
 				uses = 1
 				category = cas_bomber
 			}
-			army_experience = 10
-			air_experience = 10
+			army_experience = 25
+			air_experience = 25
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH FOCUS_FILTER_ARMY_XP FOCUS_FILTER_AIR_XP }
 	}
@@ -1229,7 +1224,7 @@ focus_tree = {
 				load_oob = "NOR_Bergjegere"
 			}
 			
-			army_experience = 10
+			army_experience = 25
 		}
 		search_filters = { FOCUS_FILTER_ARMY_XP }
 	}
@@ -1241,7 +1236,7 @@ focus_tree = {
 		x = -2
 		y = 3
 		relative_position_id = NOR_army
-		cost = 10
+		cost = 35
 		
 		available_if_capitulated = yes
 		available = {
@@ -1284,7 +1279,7 @@ focus_tree = {
 				}
 			}
 			
-			army_experience = 10
+			army_experience = 25
 		}
 		search_filters = { FOCUS_FILTER_MANPOWER FOCUS_FILTER_ARMY_XP }
 	}
@@ -1311,11 +1306,11 @@ focus_tree = {
 			add_tech_bonus = {
 				name = NOR_field_medicine_bonus
 				bonus = 1.0
-				uses = 1
+				uses = 2
 				category = hospital_tech
 			}
 			
-			army_experience = 10
+			army_experience = 25
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH FOCUS_FILTER_ARMY_XP }
 	}
@@ -1348,7 +1343,7 @@ focus_tree = {
 		completion_reward = {
 			set_technology = { bicycle_infantry = 1 }
 			
-			army_experience = 10
+			army_experience = 25
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH FOCUS_FILTER_ARMY_XP }
 	}
@@ -1386,7 +1381,7 @@ focus_tree = {
 				add_tech_bonus = {
 					name = armor_bonus
 					bonus = 1.0
-					uses = 1
+					uses = 2
 					category = armor
 				}
 			}
@@ -1452,7 +1447,7 @@ focus_tree = {
 			}
 			custom_effect_tooltip = NOR_armored_battalions_tt
 			
-			army_experience = 20
+			army_experience = 25
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH FOCUS_FILTER_ARMY_XP }
 	}
@@ -1610,15 +1605,16 @@ focus_tree = {
 		x = 1
 		y = 1
 		relative_position_id = NOR_army
-		cost = 5
+		cost = 10
 
 		available_if_capitulated = yes
 
 		completion_reward = {
+			army_experience = 25
 			add_tech_bonus = {
 				name = infantry_artillery_bonus
 				bonus = 1.0
-				uses = 1
+				uses = 2
 				category = infantry_weapons
 				category = artillery
 			}
@@ -1767,6 +1763,7 @@ focus_tree = {
 		available_if_capitulated = yes
 		
 		completion_reward = {
+			add_war_support = 0.10
 			swap_ideas = {
 				remove_idea = NOR_meager_defense_budget
 				add_idea = NOR_new_defense_budget
@@ -1806,7 +1803,7 @@ focus_tree = {
 				}
 			}
 			
-			add_war_support = 0.03
+			
 		}
 		search_filters = { FOCUS_FILTER_INDUSTRY FOCUS_FILTER_WAR_SUPPORT }
 	}
@@ -1897,7 +1894,16 @@ focus_tree = {
 		
 		completion_reward = {
 			random_owned_controlled_state = {
-				prioritize = { 142 }
+				prioritize = { 967 }
+				add_extra_state_shared_building_slots = 2
+				add_building_construction = {
+					type = arms_factory
+					level = 2
+					instant_build = yes
+				}
+			}
+			random_owned_controlled_state = {
+				prioritize = { 110 }
 				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = arms_factory
@@ -1958,16 +1964,16 @@ focus_tree = {
 			}
 			random_owned_controlled_state = {
 				prioritize = { 144 }
-				add_extra_state_shared_building_slots = 1
+				add_extra_state_shared_building_slots = 3
 				add_building_construction = {
 					type = arms_factory
-					level = 1
+					level = 3
 					instant_build = yes
 				}
 			}
 			add_timed_idea = {
 				idea = NOR_state_investments
-				days = 120
+				days = 60
 			}
 		}
 		search_filters = { FOCUS_FILTER_INDUSTRY }
@@ -2029,6 +2035,31 @@ focus_tree = {
 		continue_if_invalid = no
 		
 		completion_reward = {
+			random_owned_controlled_state = {
+				prioritize = { 110 }
+				add_building_construction = {
+					type = Infrastructure
+					level = 2
+					instant_build = yes
+				}
+			}
+			random_owned_controlled_state = {
+				prioritize = { 967 }
+				add_building_construction = {
+					type = Infrastructure
+					level = 2
+					instant_build = yes
+				}
+			}
+			random_owned_controlled_state = {
+				prioritize = { 142 }
+				add_building_construction = {
+					type = Infrastructure
+					level = 2
+					instant_build = yes
+				}
+			}
+			
 			if = {
 				limit = {
 					NOT = { has_variable = NOR.railroad_development }
@@ -2038,21 +2069,8 @@ focus_tree = {
 					value = 0
 				}
 			}
-			build_railway = {
-				level = 2
-				build_only_on_allied = yes
-				controller_priority = {
-					base = 1
-					
-					modifier = {
-						tag = ROOT
-						add = 2
-					}
-				}
-				fallback = yes
-				path = { 6115 11184 3007 6160 3021 11028 }
-			}
-			add_equipment_to_stockpile = { type = train_equipment_1 amount = 4 producer = NOR }
+			
+			add_equipment_to_stockpile = { type = train_equipment_1 amount = 25 producer = NOR }
 			
 			unlock_decision_category_tooltip = NOR_railroad_development
 		}
@@ -2103,7 +2121,22 @@ focus_tree = {
 		continue_if_invalid = no
 		
 		completion_reward = {
-			add_political_power = 75
+			random_owned_controlled_state = {
+				prioritize = { 143 }
+				add_building_construction = {
+					type = Infrastructure
+					level = 3
+					instant_build = yes
+				}
+			}
+			random_owned_controlled_state = {
+				prioritize = { 144 }
+				add_building_construction = {
+					type = Infrastructure
+					level = 3
+					instant_build = yes
+				}
+			}
 			
 			build_railway = {
 				level = 2
@@ -2119,7 +2152,7 @@ focus_tree = {
 				fallback = yes
 				path = { 3022 6038 9132 6173 9069 9208 3126 3088 3048 173 6214 9126 }
 			}
-			add_equipment_to_stockpile = { type = train_equipment_1 amount = 4 producer = NOR }
+			add_equipment_to_stockpile = { type = train_equipment_1 amount = 25 producer = NOR }
 			
 			add_to_variable = { var = NOR.railroad_development value = 2 }
 			custom_effect_tooltip = NOR_railroad_development_add_2_tt
@@ -2158,7 +2191,7 @@ focus_tree = {
 		x = 0
 		y = 2
 		relative_position_id = NOR_de_norske_statsbaner
-		cost = 5
+		cost = 10
 		ai_will_do = {
 			base = 10
 		}
@@ -2172,17 +2205,17 @@ focus_tree = {
 		completion_reward = {
 			random_owned_controlled_state = {
 				prioritize = { 144 }
-				add_extra_state_shared_building_slots = 1
+				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = industrial_complex
-					level = 1
+					level = 2
 					instant_build = yes
 				}
 			}
 			add_tech_bonus = {
 				name = industrial_bonus
-				bonus = 1.0
-				uses = 1
+				bonus = 0.5
+				uses = 2
 				category = industry
 			}
 		}
@@ -2217,6 +2250,15 @@ focus_tree = {
 		}
 		
 		completion_reward = {
+			random_owned_controlled_state = {
+				prioritize = { 143 }
+				add_extra_state_shared_building_slots = 1
+				add_building_construction = {
+					type = steel_mill
+					level = 1
+					instant_build = yes
+				}
+			}
 			143 = {
 				add_resource = {
 					type = steel
@@ -2503,15 +2545,15 @@ focus_tree = {
 		completion_reward = {
 			add_tech_bonus = {
 				name = NOR_electronics_bonus
-				bonus = 1.0
-				uses = 1
+				bonus = 0.5
+				uses = 2
 				category = electronics
 			}
 			add_tech_bonus = {
 				name = synth_bonus
-				bonus = 1.0
-				uses = 1
-				category = synth_resources
+				bonus = 0.5
+				uses = 2
+				category = industry
 			}
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH }
@@ -2672,10 +2714,10 @@ focus_tree = {
 			}
 			random_owned_controlled_state = {
 				prioritize = { 144 }
-				add_extra_state_shared_building_slots = 1
+				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = aluminum_mill
-					level = 1
+					level = 2
 					instant_build = yes
 				}
 			}
@@ -5401,10 +5443,7 @@ focus_tree = {
 		
 		completion_reward = {
 			add_ideas = NOR_kongens_garde
-			add_timed_idea = {
-				idea = NOR_wave_of_monarchism
-				days = 365
-			}
+			add_ideas = NOR_wave_of_monarchism
 			set_party_name = { ideology = neutrality long_name = Monarkistkoalisjonen name = Monarkistkoalisjonen }
 			
 			if = {
@@ -5529,8 +5568,8 @@ focus_tree = {
 			
 			custom_effect_tooltip = NOR_traditions_worth_fighting_for_tt
 			
-			army_experience = 20
-			add_stability = -0.20
+			army_experience = 50
+			add_stability = -0.10
 		}
 		search_filters = { FOCUS_FILTER_POLITICAL FOCUS_FILTER_STABILITY FOCUS_FILTER_WAR_SUPPORT FOCUS_FILTER_ARMY_XP }
 	}

--- a/common/national_focus/pakistan.txt
+++ b/common/national_focus/pakistan.txt
@@ -510,8 +510,8 @@ focus_tree = {
                         }
                     }
                 }
-			PAK = { random_owned_controlled_state = {add_extra_state_shared_building_slots = 1 add_building_construction = { type = arms_factory level = 1 instant_build = yes}  } }
-			PAK = { random_owned_controlled_state = {add_extra_state_shared_building_slots = 1 add_building_construction = { type = arms_factory level = 2 instant_build = yes}  } }
+			PAK = { random_owned_controlled_state = {add_extra_state_shared_building_slots = 2 add_building_construction = { type = arms_factory level = 2 instant_build = yes}  } }
+			PAK = { random_owned_controlled_state = {add_extra_state_shared_building_slots = 2 add_building_construction = { type = arms_factory level = 2 instant_build = yes}  } }
             }}
 
     }
@@ -803,6 +803,7 @@ focus_tree = {
         y = 5
 		completion_reward = {
 			add_ideas = GER_purge_political_opponents_idea
+            remove_ideas = RAJ_Caste_Debuff_1
 		}
 
     }
@@ -1126,7 +1127,7 @@ focus_tree = {
                     }
                 }
 			random_owned_controlled_state = {add_extra_state_shared_building_slots = 2 add_building_construction = { type = industrial_complex level = 2 instant_build = yes}  }
-			random_owned_controlled_state = {add_extra_state_shared_building_slots = 1 add_building_construction = { type = industrial_complex level = 1 instant_build = yes}  }
+			random_owned_controlled_state = {add_extra_state_shared_building_slots = 2 add_building_construction = { type = industrial_complex level = 2 instant_build = yes}  }
             }
 		}
 
@@ -1164,6 +1165,7 @@ focus_tree = {
 		 ai_will_do = { factor = 30 }
 		completion_reward = {
 			add_ideas = workers_culture
+            remove_ideas = RAJ_Caste_Debuff_1
 		}
 
     }
@@ -1231,13 +1233,14 @@ focus_tree = {
 		 ai_will_do = { factor = 30 }
 		completion_reward = {
 			add_ideas = PAK_Curb_Extremist_Influence
+            remove_ideas = RAJ_Caste_Debuff_1
 		}
 
     }
     focus = {
         id = PAK_Muslim_Unity
         icon = GFX_focus_GRE_state_expansion
-        cost = 20.00
+        cost = 10
         prerequisite = {
             focus = PAK_Work_for_Pakistan
         }
@@ -1254,6 +1257,7 @@ focus_tree = {
         y = 6
 		 ai_will_do = { factor = 15 }
 		completion_reward = {
+            remove_ideas = RAJ_Caste_Debuff_1
 			custom_effect_tooltip = pak_mus_unity
 		}
 
@@ -1872,10 +1876,10 @@ focus_tree = {
                     }
 					is_in_home_area = yes
                 }
-                add_extra_state_shared_building_slots = 1
+                add_extra_state_shared_building_slots = 2
                 add_building_construction = {
                     type = industrial_complex
-                    level = 1
+                    level = 2
                     instant_build = yes
                 }
             }
@@ -1888,10 +1892,10 @@ focus_tree = {
                     }
 					is_in_home_area = yes
                 }
-                add_extra_state_shared_building_slots = 1
+                add_extra_state_shared_building_slots = 2
                 add_building_construction = {
                     type = industrial_complex
-                    level = 1
+                    level = 2
                     instant_build = yes
                 }
             }
@@ -2079,10 +2083,10 @@ focus_tree = {
                     }
 					is_in_home_area = yes
                 }
-                add_extra_state_shared_building_slots = 1
+                add_extra_state_shared_building_slots = 2
                 add_building_construction = {
                     type = industrial_complex
-                    level = 1
+                    level = 2
                     instant_build = yes
                 }
             }
@@ -2095,10 +2099,10 @@ focus_tree = {
                     }
 					is_in_home_area = yes
                 }
-                add_extra_state_shared_building_slots = 1
+                add_extra_state_shared_building_slots = 2
                 add_building_construction = {
                     type = industrial_complex
-                    level = 1
+                    level = 2
                     instant_build = yes
                 }
             }

--- a/common/national_focus/persia.txt
+++ b/common/national_focus/persia.txt
@@ -7,6 +7,7 @@ focus_tree = {
 			tag = PER
 		}
 	}
+	shared_focus = GEN_Industrial_Boom
 	shared_focus = PER_UNIFIED_persian_imperial_ambitions
 	continuous_focus_position = { x = 50 y = 750 }
 	default = no
@@ -3048,5 +3049,50 @@ focus_tree = {
 				}
 				search_filters = { FOCUS_FILTER_INDUSTRY }
 
+	}
+	focus = {
+		id = PER_invest_in_steel
+		icon = GFX_focus_generic_steel
+		prerequisite = { focus = PER_increase_textile_production }
+		x = 1
+		y = 1
+		relative_position_id = PER_increase_textile_production
+		cost = 10
+		ai_will_do = {
+			base = 10
+		}
+
+		completion_reward = {
+
+				random_owned_controlled_state = {
+
+					add_extra_state_shared_building_slots = 4
+					add_building_construction = {
+						type = industrial_complex
+						level = 2
+						instant_build = yes
+					}
+					add_building_construction = {
+						type = steel_mill
+						level = 2
+						instant_build = yes
+					}				
+					add_resource = {
+						type = steel
+						amount = 12
+					}			
+				}
+				modify_building_resources = {
+					building = steel_mill
+					resource = steel
+					amount = 2
+				}
+				add_tech_bonus = {
+					ahead_reduction = 2
+					uses = 2
+					bonus = 1
+					category = steel_tech	
+				}
+			}
 	}
 }

--- a/common/national_focus/philippines.txt
+++ b/common/national_focus/philippines.txt
@@ -1965,14 +1965,11 @@ focus = {
 		}
 
 		available = {
-			controls_state = 646
-			controls_state = 647
-			controls_state = 684
-			controls_state = 638
+			
 		}
 
 		completion_reward = {
-			647 = {
+			random_owned_controlled_state = {
 				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = industrial_complex
@@ -1980,7 +1977,7 @@ focus = {
 					instant_build = yes
 				} 
 			}
-			646 = {
+			random_owned_controlled_state = {
 				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = industrial_complex
@@ -1988,7 +1985,7 @@ focus = {
 					instant_build = yes
 				}
 			}	
-			684 = {
+			random_owned_controlled_state = {
 				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = arms_factory
@@ -1996,7 +1993,7 @@ focus = {
 					instant_build = yes
 				}
 			}
-			638 = {
+			random_owned_controlled_state = {
 				add_extra_state_shared_building_slots = 2
 		 		add_building_construction = {
 					type = arms_factory

--- a/common/national_focus/r56_canada.txt
+++ b/common/national_focus/r56_canada.txt
@@ -103,7 +103,7 @@ focus_tree = {
 		relative_position_id = r56_CAN_modernize_industry
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 
-		cost = 8
+		cost = 10
 
 		ai_will_do = {
 			factor = 15
@@ -122,6 +122,14 @@ focus_tree = {
 
 
 		completion_reward = {
+			random_owned_controlled_state = {
+				add_extra_state_shared_building_slots = 2
+				add_building_construction = {
+					type = industrial_complex
+					level = 2
+					instant_build = yes
+				}
+			}
 			r56_CAN_depression = yes
 			custom_effect_tooltip = available_political_advisor
 			show_ideas_tooltip = r56_CAN_william_daum_euler
@@ -199,7 +207,7 @@ focus_tree = {
 		relative_position_id = r56_CAN_wheat_board
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 
-		cost = 8
+		cost = 10
 
 		ai_will_do = {
 			factor = 15
@@ -218,6 +226,14 @@ focus_tree = {
 
 
 		completion_reward = {
+			random_owned_controlled_state = {
+				add_extra_state_shared_building_slots = 2
+				add_building_construction = {
+					type = industrial_complex
+					level = 2
+					instant_build = yes
+				}
+			}
 			r56_CAN_depression = yes
 		}
 	}
@@ -281,7 +297,7 @@ focus_tree = {
 		relative_position_id = r56_CAN_enlist_the_unemployed
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 
-		cost = 5
+		cost = 10
 
 		ai_will_do = {
 			factor = 10
@@ -296,7 +312,7 @@ focus_tree = {
 
 		available = {
 			OR = {
-				threat > 0.30
+				threat > 0.40
 				has_government = fascism
 				has_government = communism
 			}
@@ -305,6 +321,16 @@ focus_tree = {
 		available_if_capitulated = yes
 
 		completion_reward = {
+			276 = {
+				add_extra_state_shared_building_slots = 2
+				add_building_construction = {
+					type = arms_factory
+					level = 2 
+					instant_build = yes
+				}
+			}
+			add_ideas = war_economy 
+			add_war_support = 0.05
 			r56_CAN_depression = yes
 		}
 	}
@@ -476,10 +502,10 @@ focus_tree = {
 		completion_reward = {
 			random_owned_controlled_state = {
 				prioritize = { 468 }
-				add_extra_state_shared_building_slots = 4
+				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = arms_factory
-					level = 4
+					level = 2
 					instant_build = yes
 				}
 			}			 			
@@ -552,10 +578,10 @@ focus_tree = {
 		
 		completion_reward = {
 			276 = {
-				add_extra_state_shared_building_slots = 3
+				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = industrial_complex
-					level = 3
+					level = 2
 					instant_build = yes
 				}
 			}
@@ -884,7 +910,15 @@ focus_tree = {
 
 		completion_reward = {
 			custom_effect_tooltip = available_designer
-			show_ideas_tooltip = r56_CAN_imperial_oil_idea		
+			show_ideas_tooltip = r56_CAN_imperial_oil_idea	
+			464 = {
+				add_extra_state_shared_building_slots = 2
+				add_building_construction = {
+					type = industrial_complex
+					level = 2
+					instant_build = yes
+				}
+			}	
 			464 = {
                 add_building_construction = {
                     type = infrastructure
@@ -1071,7 +1105,15 @@ focus_tree = {
 
 
 		completion_reward = {
-			276 = {
+			random_owned_controlled_state = {
+				add_extra_state_shared_building_slots = 2
+				add_building_construction = {
+					type = arms_factory
+					level = 2 
+					instant_build = yes
+				}
+			}
+			random_owned_controlled_state = {
 				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = arms_factory

--- a/common/national_focus/r56_canada.txt
+++ b/common/national_focus/r56_canada.txt
@@ -103,7 +103,7 @@ focus_tree = {
 		relative_position_id = r56_CAN_modernize_industry
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 
-		cost = 5
+		cost = 8
 
 		ai_will_do = {
 			factor = 15
@@ -160,7 +160,7 @@ focus_tree = {
 		x = 0
 		y = 1
 		relative_position_id = r56_CAN_depression_recovery
-		cost = 5
+		cost = 10
 
 
 		ai_will_do = {
@@ -199,7 +199,7 @@ focus_tree = {
 		relative_position_id = r56_CAN_wheat_board
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 
-		cost = 5
+		cost = 8
 
 		ai_will_do = {
 			factor = 15
@@ -863,7 +863,7 @@ focus_tree = {
 		relative_position_id = r56_CAN_alcan
 		search_filters = { FOCUS_FILTER_INDUSTRY FOCUS_FILTER_OIL }
 
-		cost = 8
+		cost = 10
 
 		ai_will_do = {
 			factor = 5
@@ -916,7 +916,7 @@ focus_tree = {
 		relative_position_id = r56_CAN_imperial_oil_focus
 		search_filters = { FOCUS_FILTER_INDUSTRY FOCUS_FILTER_RESEARCH FOCUS_FILTER_OIL FOCUS_FILTER_RUBBER }
 
-		cost = 8
+		cost = 10
 
 		ai_will_do = {
 			factor = 5
@@ -1495,7 +1495,7 @@ focus_tree = {
 		
 		search_filters = { FOCUS_FILTER_RESEARCH }
 
-		cost = 6
+		cost = 10
 
 		ai_will_do = {
 			factor = 5
@@ -1511,7 +1511,7 @@ focus_tree = {
 			army_experience = 25
 			add_doctrine_cost_reduction = {
 				name = GFX_goal_CAN_coa_army
-				cost_reduction = 0.5
+				cost_reduction = 1
 				uses = 2
 				category = land_doctrine
 			}
@@ -1609,7 +1609,7 @@ focus_tree = {
 		
 		search_filters = { FOCUS_FILTER_RESEARCH }
 
-		cost = 7
+		cost = 10
 
 		ai_will_do = {
 			factor = 5
@@ -1625,6 +1625,7 @@ focus_tree = {
 
 
 		completion_reward = {
+			army_experience = 25
 			add_tech_bonus = {
 				name = infantry_bonus
 				bonus = 1
@@ -1644,7 +1645,7 @@ focus_tree = {
 		
 		search_filters = { FOCUS_FILTER_RESEARCH }
 
-		cost = 7
+		cost = 10
 
 		ai_will_do = {
 			factor = 5
@@ -1660,6 +1661,7 @@ focus_tree = {
 
 
 		completion_reward = {
+			army_experience = 15
 			add_tech_bonus = {
 				name = r56_CAN_royal_canadian_artillery
 				bonus = 1.0
@@ -1993,7 +1995,7 @@ focus_tree = {
 				}
 				add_tech_bonus = {
 					name = armor_bonus
-					bonus = 0.75
+					bonus = 1
 					uses = 2
 					category = armor
 				}				
@@ -2069,7 +2071,7 @@ focus_tree = {
 		relative_position_id = r56_CAN_royal_canadian_artillery
 		search_filters = { FOCUS_FILTER_INDUSTRY FOCUS_FILTER_RESEARCH }
 
-		cost = 5
+		cost = 10
 		
 		prerequisite = {
 			focus = r56_CAN_royal_canadian_artillery
@@ -2341,7 +2343,7 @@ focus_tree = {
 		relative_position_id = r56_CAN_western_air_command
 		search_filters = { FOCUS_FILTER_RESEARCH }
 		
-		cost = 5
+		cost = 8
 		
 		prerequisite = {
 			focus = r56_CAN_western_air_command
@@ -2709,7 +2711,7 @@ focus_tree = {
 				name = naval_bomber
 				bonus = 1.0
 				uses = 1
-				category = naval_bomber
+				category = air_equipment
 			}
 			custom_effect_tooltip = available_designer
 			show_ideas_tooltip = r56_fairchild_aircraft_ltd
@@ -2763,7 +2765,7 @@ focus_tree = {
 				name = r56_CAN_victory_aircraft_company
 				bonus = 1.0
 				uses = 1
-				category = cat_strategic_bomber
+				category = medium_air
 			}
 			custom_effect_tooltip = available_designer
 			show_ideas_tooltip = CAN_victory_aircraft
@@ -2779,7 +2781,7 @@ focus_tree = {
 		
 		search_filters = { FOCUS_FILTER_RESEARCH }
 
-		cost = 4
+		cost = 5
 		
 		prerequisite = {
 			focus = r56_CAN_fairchild_aircraft_company
@@ -2796,11 +2798,9 @@ focus_tree = {
 		completion_reward = {
 			add_doctrine_cost_reduction = {
 				name = air_doctrine
-				cost_reduction = 0.5
+				cost_reduction = 1
 				uses = 2
-				technology = massed_bomber_formations
-				technology = strategic_destruction
-				technology = infiltration_bombing
+				category = air_doctrine
 			}
 		}
 	}
@@ -3075,22 +3075,8 @@ focus_tree = {
 					instant_build = yes
 				}
 			}
-			464 = {
-			add_extra_state_shared_building_slots = 3
-			add_building_construction = {
-				type = dockyard
-				level = 3
-				instant_build = yes
-				}
-			}
-			468 = {
-				add_extra_state_shared_building_slots = 3
-				add_building_construction = {
-					type = dockyard
-					level = 3
-					instant_build = yes
-				}
-			}
+			
+			
 		}
 	}
 	

--- a/common/national_focus/r56_gen_shared.txt
+++ b/common/national_focus/r56_gen_shared.txt
@@ -1506,7 +1506,7 @@
 		id = GEN_Industrial_Boom
 		icon = GFX_goal_pp
 
-		x = 43
+		x = 65
 		y = 0
 		offset = {
 			x = 22

--- a/common/national_focus/romania.txt
+++ b/common/national_focus/romania.txt
@@ -1639,10 +1639,10 @@ focus_tree = {
 				limit = {
 					has_state_flag = ROM_malaxa_IC
 				}
-				add_extra_state_shared_building_slots = 4
+				add_extra_state_shared_building_slots = 3
 				add_building_construction = {
 					type = industrial_complex
-					level = 4
+					level = 3
 					instant_build = yes
 				}
 			}
@@ -1661,10 +1661,10 @@ focus_tree = {
 						include_locked = yes
 					}
 				}
-				add_extra_state_shared_building_slots = 4
+				add_extra_state_shared_building_slots = 3
 				add_building_construction = {
 					type = industrial_complex
-					level = 4
+					level = 3
 					instant_build = yes
 				}
 				set_state_flag = ROM_malaxa_IC
@@ -1763,10 +1763,10 @@ focus_tree = {
 						include_locked = yes
 					}
 				}
-				add_extra_state_shared_building_slots = 3
+				add_extra_state_shared_building_slots = 4
 				add_building_construction = {
 					type = industrial_complex
-					level = 1
+					level = 2
 					instant_build = yes
 				}
 				add_building_construction = {
@@ -1821,10 +1821,10 @@ focus_tree = {
 				limit = {
 					has_state_flag = ROM_invest_in_the_iar_AF1
 				}
-				add_extra_state_shared_building_slots = 2
+				add_extra_state_shared_building_slots = 3
 				add_building_construction = {
 					type = arms_factory
-					level = 2
+					level = 3
 					instant_build = yes
 				}
 			}
@@ -1841,10 +1841,10 @@ focus_tree = {
 						include_locked = yes
 					}
 				}
-				add_extra_state_shared_building_slots = 2
+				add_extra_state_shared_building_slots = 3
 				add_building_construction = {
 					type = arms_factory
-					level = 2
+					level = 3
 					instant_build = yes
 				}
 				set_state_flag = ROM_invest_in_the_iar_AF1
@@ -2108,12 +2108,12 @@ focus_tree = {
 			factor = 40
 		}
 
-		# allow_branch = {
-		# 	has_game_rule = {
-		# 		rule = rom_fragmentation_status
-		# 		option = ROM_FRAGMENTED
-		# 	}
-		# }
+		 allow_branch = {
+		 	has_game_rule = {
+		 		rule = rom_fragmentation_status
+		 		option = ROM_FRAGMENTED
+		 	}
+		 }
 		available = {
 			is_subject = no
 			OR = {

--- a/common/national_focus/romania.txt
+++ b/common/national_focus/romania.txt
@@ -2087,13 +2087,13 @@ focus_tree = {
 				limit = {
 					is_ai = no
 				}
-				has_army_manpower = { size > 400000 }
+				has_army_manpower = { size > 250000 }
 			}
 			if = {
 				limit = {
 					is_ai = yes
 				}
-				has_army_manpower = { size > 400000 }
+				has_army_manpower = { size > 250000 }
 			}
 		}
  
@@ -2143,13 +2143,13 @@ focus_tree = {
 				limit = {
 					is_ai = no
 				}
-				has_army_manpower = { size > 500000 }
+				has_army_manpower = { size > 200000 }
 			}
 			if = {
 				limit = {
 					is_ai = yes
 				}
-				has_army_manpower = { size > 420000 }
+				has_army_manpower = { size > 200000 }
 			}
 		}
  
@@ -2199,13 +2199,13 @@ focus_tree = {
 				limit = {
 					is_ai = no
 				}
-				has_army_manpower = { size > 500000 }
+				has_army_manpower = { size > 300000 }
 			}
 			if = {
 				limit = {
 					is_ai = yes
 				}
-				has_army_manpower = { size > 420000 }
+				has_army_manpower = { size > 300000 }
 			}
 		}
  

--- a/common/national_focus/romania.txt
+++ b/common/national_focus/romania.txt
@@ -65,7 +65,7 @@ focus_tree = {
 		id = ROM_preserve_greater_romania
 		icon = GFX_focus_rom_preserve_romania
 		mutually_exclusive = { focus = ROM_balkans_dominance }
-		x = 3
+		x = 5
 		y = 0
 
 		cost = 6
@@ -1013,7 +1013,7 @@ focus_tree = {
 		id = ROM_invite_ukraine
 		icon = GFX_focus_generic_ukrainian_deal
 		prerequisite = { focus = ROM_the_cordon_sanitaire }
-		x = 1
+		x = 0
 		y = 1
 		relative_position_id = ROM_the_cordon_sanitaire
 
@@ -1048,10 +1048,10 @@ focus_tree = {
 	focus = {
 		id = ROM_demand_a_western_guarantee
 		icon = GFX_goal_generic_befriend_romania
-		prerequisite = { focus = ROM_renew_the_romanian_polish_alliance }
+		prerequisite = { focus = ROM_obtain_polish_cryptological_data }
 		x = 0
-		y = 2
-		relative_position_id = ROM_renew_the_romanian_polish_alliance
+		y = 1
+		relative_position_id = ROM_obtain_polish_cryptological_data
 
 		cost = 5
 
@@ -1119,10 +1119,11 @@ focus_tree = {
 	focus = {
 		id = ROM_military_modernization
 		icon = GFX_goal_generic_army_artillery
-		prerequisite = { focus = ROM_demand_a_western_guarantee }
-		x = 1
-		y = 3
-		relative_position_id = ROM_renew_the_romanian_polish_alliance
+		prerequisite = { focus = ROM_demand_a_western_guarantee  }
+		prerequisite = { focus = ROM_invite_ukraine }
+		x = -1
+		y = 1
+		relative_position_id = ROM_invite_ukraine
 
 		cost = 5
 
@@ -1153,175 +1154,16 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL }
 	}
 
-	focus = {
-		id = ROM_join_allies
-		icon = GFX_goal_support_democracy
-		prerequisite = { focus = ROM_demand_a_western_guarantee }
-		x = 0
-		y = 4
-		relative_position_id = ROM_renew_the_romanian_polish_alliance
 
-		cost = 10
-
-		ai_will_do = {
-			factor = 1
-			modifier = {
-				factor = 0.2
-				ENG = { surrender_progress > 0.2 }
-			}
-			modifier = {
-				factor = 0.01
-				OR = {
-					ENG = {
-						has_capitulated = yes
-					}
-					FRA = {
-						has_capitulated = yes
-					}
-				}
-			}
-			modifier = {
-				factor = 0.01
-				has_idea = GER_align_romania
-				fascism > 0.4
-				
-			}			
-		}
-
-		available = {			
-			any_other_country = {
-				NOT = { has_war_with = ROOT }
-				is_faction_leader = yes
-				is_major = yes
-				has_government = democratic
-			}
-			is_puppet = no
-			is_in_faction = no
-		}
-
-		bypass = {
-			is_in_faction_with = ENG
-		}
-
-		
-		
-		available_if_capitulated = yes
-
-
-		completion_reward = {
-			if = {
-				limit = {
-					ENG = {
-						has_government = democratic
-						is_faction_leader = yes
-						has_capitulated = no
-					}
-				}
-				ENG = {
-					country_event = generic.2
-				}
-			}
-			else_if = {
-				limit = {
-					USA = {
-						has_government = democratic
-						is_faction_leader = yes
-						has_capitulated = no
-					}
-				}
-				USA = {
-					country_event = generic.2
-				}
-			}
-			else_if = {
-				limit = {
-					any_other_country = {
-						has_government = democratic
-						is_faction_leader = yes
-						is_major = yes
-						has_capitulated = no
-						num_of_factories > 70
-					}
-				}
-				random_other_country = {
-					limit = {
-						has_government = democratic
-						is_faction_leader = yes
-						is_major = yes
-						num_of_factories > 70
-					}
-					country_event = generic.2
-				}				
-			}
-			else_if = {
-				limit = {
-					any_other_country = {
-						has_government = democratic
-						is_faction_leader = yes
-						is_major = yes
-						has_capitulated = no
-						num_of_factories > 50
-					}
-				}
-				random_other_country = {
-					limit = {
-						has_government = democratic
-						is_faction_leader = yes
-						is_major = yes
-						num_of_factories > 50
-					}
-					country_event = generic.2
-				}				
-			}			
-			else_if = {
-				limit = {
-					any_other_country = {
-						has_government = democratic
-						is_faction_leader = yes
-						is_major = yes
-						has_capitulated = no
-					}
-				}
-				random_other_country = {
-					limit = {
-						has_government = democratic
-						is_faction_leader = yes
-						is_major = yes
-						has_capitulated = no
-					}
-					country_event = generic.2
-				}
-			}
-			else_if = {
-				limit = {
-					any_other_country = {
-						has_government = democratic
-						is_faction_leader = yes
-
-						has_capitulated = no
-					}
-				}
-				random_other_country = {
-					limit = {
-						has_government = democratic
-						is_faction_leader = yes
-						has_capitulated = no
-					}
-					country_event = generic.2
-				}
-			}
-		}
-		search_filters = { FOCUS_FILTER_ALLIANCE }
-	}
 
 	focus = {
 		id = ROM_joint_allied_staff_college
 		icon = GFX_goal_generic_democratic_army
-		prerequisite = { focus = ROM_join_allies }
+		
 		prerequisite = { focus = ROM_military_modernization }
-		x = 1
-		y = 5
-		relative_position_id = ROM_renew_the_romanian_polish_alliance
+		x = 0
+		y = 1
+		relative_position_id = ROM_military_modernization
 
 		cost = 10
 
@@ -1330,8 +1172,7 @@ focus_tree = {
 		}
 
 		available = {
-			is_in_faction_with = ENG
-			ENG = { is_faction_leader = yes }
+			
 		}
 
 
@@ -1343,13 +1184,8 @@ focus_tree = {
 
 		completion_reward = {
 			add_to_tech_sharing_group = ROM_joint_allied_staff_college_tech_group
-			ENG = { add_to_tech_sharing_group = ROM_joint_allied_staff_college_tech_group }
-			if = {
-				limit = {
-					FRA = { is_in_faction_with = ENG }
-				}
-				FRA = { add_to_tech_sharing_group = ROM_joint_allied_staff_college_tech_group }
-			}
+			
+			
 			every_army_leader = {
 				add_planning = 1
 			}
@@ -1357,7 +1193,7 @@ focus_tree = {
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH }
 	}
-
+	
 	############################
 	##### INDUSTRY BRANCH ######
 	############################
@@ -1995,7 +1831,7 @@ focus_tree = {
 		id = ROM_balkans_dominance
 		icon = GFX_goal_ROM_balkans_domination
 		mutually_exclusive = { focus = ROM_preserve_greater_romania }
-		x = 15
+		x = 18
 		y = 0
 
 		cost = 10
@@ -2242,12 +2078,11 @@ focus_tree = {
 			has_civil_war = no
 			HUN = {
 				exists = yes
-				NOT = { has_war_with = ROM }
+				NOT = {
+					is_in_faction_with = ROM
+				}
 			}
-			strength_ratio = {
-				tag = HUN
-				ratio > 1.5
-			}
+			strength_ratio = { tag = HUN ratio > 1 }
 			if = {
 				limit = {
 					is_ai = no
@@ -2258,31 +2093,25 @@ focus_tree = {
 				limit = {
 					is_ai = yes
 				}
-				has_army_manpower = { size > 320000 }
+				has_army_manpower = { size > 400000 }
 			}
-			NOT = {
-				has_completed_focus = ROM_preserve_greater_romania
-			}			
 		}
-
+ 
 		bypass = {
 			HUN = {
 				OR = {
 					is_puppet_of = ROM
 					exists = no 
-					is_ai = no
 				}
 			}
 		}
 
-
-
-		cancel_if_invalid = yes
-		continue_if_invalid = no
-		available_if_capitulated = no
-
 		completion_reward = {
-			HUN = { country_event = DOD_romania.50 }
+			create_wargoal = {
+				type = puppet_wargoal_focus
+				target = HUN
+				expire = 0
+			}
 		}
 	}
 
@@ -2302,45 +2131,43 @@ focus_tree = {
 
 		available = {
 			is_subject = no
+			has_civil_war = no
 			BUL = {
 				exists = yes
-				NOT = { has_war_with = ROM }
+				NOT = {
+					is_in_faction_with = ROM
+				}
 			}
-			strength_ratio = { tag = BUL ratio > 1.5 }
+			strength_ratio = { tag = GRE ratio > 1 }
 			if = {
 				limit = {
 					is_ai = no
 				}
-				has_army_manpower = { size > 400000 }
+				has_army_manpower = { size > 500000 }
 			}
 			if = {
 				limit = {
 					is_ai = yes
 				}
-				has_army_manpower = { size > 320000 }
+				has_army_manpower = { size > 420000 }
 			}
 		}
-
+ 
 		bypass = {
 			BUL = {
 				OR = {
 					is_puppet_of = ROM
 					exists = no 
-					AND = {
-						has_war_with = ROM
-						has_capitulated = yes
-						ROM = {
-							controls_state = 48
-							controls_state = 212
-							controls_state = 211
-						}
-					}
 				}
 			}
 		}
 
 		completion_reward = {
-			BUL = { country_event = DOD_romania.40 }
+			create_wargoal = {
+				type = puppet_wargoal_focus
+				target = BUL
+				expire = 0
+			}
 		}
 	}
 
@@ -2484,40 +2311,43 @@ focus_tree = {
 
 		available = {
 			is_subject = no
+			has_civil_war = no
 			CZE = {
 				exists = yes
-				is_puppet = no
-				NOT =  { is_in_faction_with = ROM }
-			}
-			strength_ratio = { tag = CZE ratio > 1.5 }
-			has_army_manpower = { size > 500000 }
-			OR = {
-				AND ={
-					country_exists = GER
-					is_puppet = no
+				NOT = {
+					is_in_faction_with = ROM
 				}
-				AND ={
-					country_exists = PRE
-					is_puppet = no
-				}				
+			}
+			strength_ratio = { tag = CZE ratio > 1 }
+			if = {
+				limit = {
+					is_ai = no
+				}
+				has_army_manpower = { size > 500000 }
+			}
+			if = {
+				limit = {
+					is_ai = yes
+				}
+				has_army_manpower = { size > 500000 }
 			}
 		}
-		completion_reward = {
-			If = {
-				limit = {
-					country_exists = GER
-					is_puppet = no
+ 
+		bypass = {
+			CZE = {
+				OR = {
+					is_puppet_of = ROM
+					exists = no 
 				}
-				GER = { country_event = DOD_romania.110 }
 			}
-			If = {
-				limit = {
-					country_exists = PRE
-					is_puppet = no
-				}
-				PRE = { country_event = DOD_romania.110 }
-			}			
-			
+		}
+
+		completion_reward = {
+			create_wargoal = {
+				type = puppet_wargoal_focus
+				target = CZE
+				expire = 0
+			}
 		}
 	}
 
@@ -2654,7 +2484,7 @@ focus_tree = {
 		id = ROM_institute_royal_dictatorship
 		icon = GFX_goal_ROM_institute_royal_dictatorship_two
 		mutually_exclusive = { focus = ROM_codreanu_goga_cooperation }
-		x = 21
+		x = 28
 		y = 0
 
 		cost = 5
@@ -2734,7 +2564,7 @@ focus_tree = {
 		id = ROM_his_majestys_loyal_government
 		icon = GFX_goal_ROM_his_majesty_loyal_government
 		prerequisite = { focus = ROM_fortify_the_borders }
-		prerequisite = { focus = ROM_align_hungary }
+		
 		prerequisite = { focus = ROM_revise_the_constitution }
 		mutually_exclusive = { focus = ROM_flexible_foreign_policy }
 		x = -1
@@ -3866,7 +3696,7 @@ focus_tree = {
 		icon = GFX_goal_support_fascism
 		
 		mutually_exclusive = { focus = ROM_institute_royal_dictatorship }
-		x = 29
+		x = 37
 		y = 0
 		
 		cost = 5
@@ -4438,7 +4268,7 @@ focus_tree = {
 	focus = {
 		id = ROM_expand_the_air_force
 		icon = GFX_goal_generic_airport
-		x = 36
+		x = 45
 		y = 0
 
 		cost = 5
@@ -4956,7 +4786,7 @@ focus_tree = {
 	focus = {
 		id = ROM_army_maneuvers
 		icon = GFX_goal_generic_army_doctrines
-		x = 44
+		x = 55
 		y = 0
 
 		cost = 5
@@ -5638,7 +5468,7 @@ focus_tree = {
 	focus = {
 		id = ROM_expand_the_galati_shipyards
 		icon = GFX_goal_generic_construct_naval_dockyard
-		x = 52
+		x = 65
 		y = 0
 
 		cost = 10

--- a/common/national_focus/saudi_arabia.txt
+++ b/common/national_focus/saudi_arabia.txt
@@ -1207,7 +1207,7 @@
 	focus = {
 		id = SAU_army_focus_1
 		icon = GFX_goal_generic_small_arms
-		cost = 5.00
+		cost = 5
 		ai_will_do = {
 			factor = 1
 		}
@@ -1220,7 +1220,7 @@
 		army_experience = 20
 		add_doctrine_cost_reduction = {
 				name = SAU_army_focus_1
-				cost_reduction = 0.5
+				cost_reduction = 1
 				uses = 2
 				category = land_doctrine
 			}
@@ -1276,7 +1276,7 @@
 	focus = {
 		id = SAU_artillery
 		icon = GFX_goal_generic_army_artillery2
-		cost = 10.00
+		cost = 10
 		prerequisite = { focus = SAU_army_infantry_desert }
 		ai_will_do = {
 			factor = 1
@@ -1298,7 +1298,7 @@
 	focus = {
 		id = SAU_land_doctrine1
 		icon = GFX_goal_generic_position_armies
-		cost = 5.00
+		cost = 5
 		prerequisite = { focus = SAU_army_infantry_desert }
 		ai_will_do = {
 			factor = 1
@@ -1310,7 +1310,7 @@
 		completion_reward = {
 			add_doctrine_cost_reduction = {
 				name = SAU_land_doctrine
-				cost_reduction = 0.5
+				cost_reduction = 1
 				uses = 2
 				category = land_doctrine
 			}
@@ -1357,7 +1357,7 @@
 			army_experience = 30
 			add_doctrine_cost_reduction = {
 				name = SAU_yemen_lessons
-				cost_reduction = 0.5
+				cost_reduction = 1
 				uses = 2
 				category = land_doctrine
 			}
@@ -1482,7 +1482,7 @@
 	focus = {
 		id = SAU_incorporate_nomad_tactics
 		icon = GFX_focus_generic_camel_corps
-		cost = 5.00
+		cost = 10
 		prerequisite = { focus = SAU_encourage_general_creativity }
 		ai_will_do = {
 			factor = 1
@@ -1736,7 +1736,51 @@
 			}
 		}
 	}
+	focus = {
+		id = SAU_invest_in_steel
+		icon = GFX_focus_generic_steel
+		prerequisite = { focus = SAU_2_Industrial_Start  }
+		x = 0
+		y = 1
+		relative_position_id = SAU_2_Industrial_Start
+		cost = 10
+		ai_will_do = {
+			base = 10
+		}
 
+		completion_reward = {
+
+				random_owned_controlled_state = {
+
+					add_extra_state_shared_building_slots = 4
+					add_building_construction = {
+						type = industrial_complex
+						level = 2
+						instant_build = yes
+					}
+					add_building_construction = {
+						type = steel_mill
+						level = 2
+						instant_build = yes
+					}				
+					add_resource = {
+						type = steel
+						amount = 12
+					}			
+				}
+				modify_building_resources = {
+					building = steel_mill
+					resource = steel
+					amount = 2
+				}
+				add_tech_bonus = {
+					ahead_reduction = 2
+					uses = 2
+					bonus = 1
+					category = steel_tech	
+				}
+			}
+	}
 	focus ={
 		id = SAU_2_Expand_Infra
 		icon = GFX_goal_generic_construct_infrastructure
@@ -3286,7 +3330,7 @@
 			
 			add_stability = 0.05
 		
-			add_timed_idea = { idea = GEN_Industrial_Boom_I days = 365 }
+			add_ideas = GEN_Industrial_Boom_I
 		}
 		search_filters = { FOCUS_FILTER_STABILITY FOCUS_FILTER_POLITICAL }
 	}
@@ -4497,17 +4541,17 @@
 		y = 1
 		relative_position_id = SAU_2_Own_Design
 		
-		cost = 5
+		cost = 10
 
 		available_if_capitulated = yes
 
 		completion_reward = {
 			add_tech_bonus = {
 				name = bomber_bonus
-				bonus = 1
-				uses = 1
-				category = cas_bomber
-				category = tactical_bomber
+				bonus = 0.5
+				uses = 2
+				category = air_equipment
+				
 			}
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH }

--- a/common/national_focus/siam.txt
+++ b/common/national_focus/siam.txt
@@ -1946,7 +1946,7 @@ focus_tree = {
 	focus = {
 		id = SIA_end_the_depression
 		icon = GFX_goal_generic_deals
-		cost = 8
+		cost = 5
 		x = 46
 		y = 0
 		ai_will_do = {
@@ -1960,7 +1960,7 @@ focus_tree = {
 	focus = {
 		id = SIA_mechanization_of_agriculture
 		icon = GFX_goal_generic_production2
-		cost = 8
+		cost = 10
 		prerequisite = {
 			focus = SIA_end_the_depression
 		}
@@ -1968,7 +1968,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = SIA_end_the_depression
 			completion_reward = {
-				add_offsite_building = { type = industrial_complex level = 1 }
+				add_offsite_building = { type = industrial_complex level = 3 }
 					random_owned_controlled_state = {
 							limit = {
 									free_building_slots = {
@@ -1992,7 +1992,7 @@ focus_tree = {
 												}
 										}
 								}
-							add_extra_state_shared_building_slots = 1
+							add_extra_state_shared_building_slots = 3
 						}
 					random_owned_controlled_state = {
 							limit = {
@@ -2017,7 +2017,7 @@ focus_tree = {
 												}
 										}
 								}
-							add_extra_state_shared_building_slots = 1
+							add_extra_state_shared_building_slots = 3
 						}
 					random_owned_controlled_state = {
 							limit = {
@@ -2042,7 +2042,7 @@ focus_tree = {
 												}
 										}
 								}
-							add_extra_state_shared_building_slots = 1
+							add_extra_state_shared_building_slots = 3
 						}
 				}
 				search_filters = { FOCUS_FILTER_INDUSTRY }
@@ -2067,7 +2067,7 @@ focus_tree = {
 		
 		relative_position_id = SIA_mechanization_of_agriculture
 		completion_reward = {
-
+			
 			724 = {
 				add_resource = {
 					type = rubber

--- a/common/national_focus/turkey.txt
+++ b/common/national_focus/turkey.txt
@@ -2516,7 +2516,7 @@ focus_tree = {
 
 		completion_reward = {
 
-				random_state = {
+				random_owned_controlled_state = {
 
 					add_extra_state_shared_building_slots = 4
 					add_building_construction = {

--- a/common/national_focus/uk.txt
+++ b/common/national_focus/uk.txt
@@ -7538,28 +7538,7 @@ focus_tree = {
 					exists = no
 				}
 			}
-			NOT = {
-				any_state = {
-					OR = {
-						is_core_of = ENG
-						is_core_of = CAN
-						is_core_of = SAF
-						is_core_of = AST
-						is_core_of = NZL
-					}
-					OWNER = {
-						NOT = {
-							OR = {
-								tag = ENG
-								tag = CAN
-								tag = SAF
-								tag = AST
-								tag = NZL
-							}
-						}
-					}
-				}
-			}
+			
 		}
 
 		bypass = {

--- a/common/national_focus/usa.txt
+++ b/common/national_focus/usa.txt
@@ -10585,10 +10585,16 @@ focus_tree = {
 		search_filters = {FOCUS_FILTER_RESEARCH}
 
 		completion_reward = {
+			add_tech_bonus = {
+				name = CAS_effort
+				uses = 1
+				bonus = 1.0
+				category = air_equipment
+			}
 			add_doctrine_cost_reduction = {
 				name = USA_us_army_airforce
 				uses = 1
-				cost_reduction = 0.5
+				cost_reduction = 1
 				category = air_doctrine
 			}
 			add_ideas = r56_USA_us_army_airforce

--- a/common/national_focus/venezuela.txt
+++ b/common/national_focus/venezuela.txt
@@ -22,7 +22,7 @@ focus_tree = {
             factor = 10
         }
         completion_reward = {
-            add_political_power = 50
+            add_political_power = 75
 
         }
     }
@@ -337,7 +337,7 @@ focus_tree = {
         x = -3
         y = 1
         relative_position_id = VEN_eleazar_contreras
-        cost = 7.2
+        cost = 6
 
         prerequisite = {
             focus = VEN_eleazar_contreras
@@ -362,7 +362,7 @@ focus_tree = {
         x = -1
         y = 1
         relative_position_id = VEN_health_and_social_assistance
-        cost = 7.2
+        cost = 7
 
         prerequisite = {
             focus = VEN_health_and_social_assistance
@@ -382,7 +382,7 @@ focus_tree = {
         x = 1
         y = 1
         relative_position_id = VEN_health_and_social_assistance
-        cost = 7.2
+        cost = 10
         available_if_capitulated = yes
         prerequisite = {
             focus = VEN_health_and_social_assistance
@@ -527,7 +527,7 @@ focus_tree = {
         icon = GFX_focus_generic_coastal_fort
         x = 34
         y = 7
-        cost = 10
+        cost = 5
 
         prerequisite = {
             focus = VEN_neutrality_focus
@@ -566,7 +566,7 @@ focus_tree = {
         icon = GFX_goal_generic_fortify_city
         x = 35
         y = 8
-        cost = 10
+        cost = 5
 
         prerequisite = {
             focus = VEN_oil_protection
@@ -651,7 +651,7 @@ focus_tree = {
         icon = GFX_goal_COL_political_effort
         x = 33
         y = 8
-        cost = 10
+        cost = 5
 
         prerequisite = {
             focus = VEN_oil_protection
@@ -716,10 +716,10 @@ focus_tree = {
         }
         completion_reward = {
             random_owned_controlled_state = {
-							add_extra_state_shared_building_slots = 1
+							add_extra_state_shared_building_slots = 3
 							add_building_construction = {
 									type = industrial_complex
-									level = 1
+									level = 3
 									instant_build = yes
 								}
                     }
@@ -731,10 +731,10 @@ focus_tree = {
 											include_locked = yes
 										}
 								}
-							add_extra_state_shared_building_slots = 1
+							add_extra_state_shared_building_slots = 3
 							add_building_construction = {
 									type = arms_factory
-									level = 1
+									level = 3
 									instant_build = yes
 								}
                     }
@@ -2523,10 +2523,7 @@ focus_tree = {
             factor = 10
         }
         completion_reward = {
-            add_timed_idea = {
-                idea = VEN_western_agreements
-                days = 90
-            }
+            add_ideas = VEN_western_agreements
 
         }
     }
@@ -2656,19 +2653,19 @@ focus_tree = {
         completion_reward = {
             random_owned_controlled_state = {
                 prioritize = { 307 }
-				add_extra_state_shared_building_slots = 1
+				add_extra_state_shared_building_slots = 2
             }
             random_owned_controlled_state = {
                 prioritize = { 489 }
-				add_extra_state_shared_building_slots = 1
+				add_extra_state_shared_building_slots = 2
             }
             random_owned_controlled_state = {
                 prioritize = { 488 }
-				add_extra_state_shared_building_slots = 1
+				add_extra_state_shared_building_slots = 2
             }
             random_owned_controlled_state = {
                 prioritize = { 948 }
-				add_extra_state_shared_building_slots = 1
+				add_extra_state_shared_building_slots = 2
             }
         }
     }
@@ -3103,7 +3100,7 @@ focus_tree = {
         x = 1
         y = 1
         relative_position_id = VEN_new_republic
-        cost = 5
+        cost = 10
 
         search_filters = {FOCUS_FILTER_INDUSTRY}
         prerequisite = {
@@ -3147,7 +3144,7 @@ focus_tree = {
         cost = 10
 
         available = {
-            has_government = democratic
+           
         }
         search_filters = {FOCUS_FILTER_POLITICAL FOCUS_FILTER_INDUSTRY}
         prerequisite = {
@@ -3169,7 +3166,7 @@ focus_tree = {
         x = 1
         y = 1
         relative_position_id = VEN_labour_reforms
-        cost = 5
+        cost = 10
 
         search_filters = {FOCUS_FILTER_INDUSTRY}
         prerequisite = {
@@ -4811,18 +4808,9 @@ focus_tree = {
             focus = VEN_allow_new_elections
         }
         available = {
-			is_in_faction = no
-			is_puppet = no
-			any_other_country = {
-				is_major = yes
-				has_government = democratic
-				is_faction_leader = yes
-				NOT = { has_war_with = ROOT }
-				has_opinion = {
-					target = ROOT
-					value > 0
-				}
-			}
+			
+			
+			
         }
         search_filters = {FOCUS_FILTER_ALLIANCE}
         ai_will_do = {
@@ -4903,8 +4891,7 @@ focus_tree = {
         cost = 10
         available_if_capitulated = yes
         available = {
-            is_in_faction = yes
-            has_war = yes
+            
         }
         prerequisite = {
             focus = VEN_embargo_japan
@@ -4966,13 +4953,13 @@ focus_tree = {
         completion_reward = {
             add_tech_bonus = {
                 name = industrial_bonus
-					bonus = 0.5
+					bonus = 1
 					uses = 1
 					category = refining_tech
 				}
             add_resource = {
                 type = oil
-                amount = 8
+                amount = 10
                 state = 307
             }
 
@@ -4983,7 +4970,7 @@ focus_tree = {
         icon = GFX_goal_fighters_uk
         x = 23
         y = 8
-        cost = 7.2
+        cost = 5
         available_if_capitulated = yes
         prerequisite = {
             focus = VEN_assisted_oil_development
@@ -5417,6 +5404,7 @@ focus_tree = {
             factor = 10
         }
         completion_reward = {
+            army_experience = 25
             division_template = {
                 name = "Guardia Civil"
                 priority = 0
@@ -5451,10 +5439,7 @@ focus_tree = {
 
         available = {
             has_completed_focus = VEN_reform_GNB
-            OR = {
-                has_war = yes
-                threat > 0.8
-            }
+            
         }
         ai_will_do = {
             factor = 0
@@ -5528,7 +5513,7 @@ focus_tree = {
         icon = GFX_goal_generic_army_doctrines
         x = -30
         y = 1
-        cost = 7.2
+        cost = 5
         available_if_capitulated = yes
         search_filters = {FOCUS_FILTER_RESEARCH}
         prerequisite = {
@@ -5538,11 +5523,11 @@ focus_tree = {
             factor = 10
         }
         completion_reward = {
-            army_experience = 20
+            army_experience = 25
             add_doctrine_cost_reduction = {
                 name = VEN_modernize_army
                 uses = 2
-                cost_reduction = 0.5
+                cost_reduction = 1
                 category = land_doctrine
             }
         }
@@ -5552,7 +5537,7 @@ focus_tree = {
         icon = GFX_goal_VEN_fortress
         x = -27
         y = 2
-        cost = 7.2
+        cost = 10
         available_if_capitulated = yes
         search_filters = {FOCUS_FILTER_RESEARCH}
         prerequisite = {
@@ -5577,7 +5562,7 @@ focus_tree = {
         icon = GFX_goal_tank_hunt
         x = -28
         y = 3
-        cost = 7.2
+        cost = 10
         available_if_capitulated = yes
         search_filters = {FOCUS_FILTER_RESEARCH}
         prerequisite = {
@@ -5603,7 +5588,7 @@ focus_tree = {
         icon = GFX_goal_airplane_hunt
         x = -26
         y = 3
-        cost = 7.2
+        cost = 7
         available_if_capitulated = yes
         search_filters = {FOCUS_FILTER_RESEARCH}
         prerequisite = {
@@ -5619,7 +5604,7 @@ focus_tree = {
             add_tech_bonus = {
                 name = secret_bonus
                 bonus = 1
-                uses = 1
+                uses = 2
                 category = radar_tech
             }
             489 = {
@@ -5643,7 +5628,7 @@ focus_tree = {
         icon = GFX_goal_ammunitions
         x = -27
         y = 4
-        cost = 7.2
+        cost = 7
         available_if_capitulated = yes
         search_filters = {FOCUS_FILTER_RESEARCH}
         prerequisite = {
@@ -5669,7 +5654,7 @@ focus_tree = {
         icon = GFX_goal_generic_modernizing_the_cavalry
         x = -33
         y = 2
-        cost = 7.2
+        cost = 10
         available_if_capitulated = yes
         search_filters = {FOCUS_FILTER_RESEARCH}
         prerequisite = {
@@ -5697,7 +5682,7 @@ focus_tree = {
         icon = GFX_goal_mechanized_offensive
         x = -34
         y = 3
-        cost = 7.2
+        cost = 8
         available_if_capitulated = yes
         prerequisite = {
             focus = VEN_modernize_calvary
@@ -5710,7 +5695,7 @@ focus_tree = {
             add_tech_bonus = {
                 name = VEN_mechanised
                 bonus = 1
-                uses = 1
+                uses = 2
                 category = cat_mechanized_equipment
             }
 
@@ -5722,7 +5707,7 @@ focus_tree = {
         icon = GFX_goal_generic_radio_development
         x = -32
         y = 3
-        cost = 7.2
+        cost = 7
         available_if_capitulated = yes
         prerequisite = {
             focus = VEN_modernize_calvary
@@ -5734,8 +5719,8 @@ focus_tree = {
         completion_reward = {
             add_tech_bonus = {
                 name = VEN_signal_companies
-                bonus = 1.5
-                uses = 1
+                bonus = 1
+                uses = 2
                 category = signal_company_tech
                 }
 
@@ -5747,7 +5732,7 @@ focus_tree = {
         icon = GFX_goal_tank_offensive
         x = -33
         y = 4
-        cost = 7.2
+        cost = 10
         available_if_capitulated = yes
         search_filters = {FOCUS_FILTER_RESEARCH}
         prerequisite = {
@@ -5763,7 +5748,7 @@ focus_tree = {
             add_tech_bonus = {
                 name = VEN_tanks
                 bonus = 1
-                uses = 1
+                uses = 2
                 category = armor
             }
 
@@ -5775,7 +5760,7 @@ focus_tree = {
         icon = GFX_focus_generic_combined_arms
         x = -30
         y = 3
-        cost = 7.2
+        cost = 10
         available_if_capitulated = yes
         search_filters = {FOCUS_FILTER_RESEARCH}
         prerequisite = {
@@ -5789,13 +5774,13 @@ focus_tree = {
             add_tech_bonus = {
                 name = VEN_modernize_weapons
                 bonus = 1
-                uses = 1
+                uses = 2
                 category = infantry_weapons
                 }
             add_tech_bonus = {
                 name = VEN_modernize_weapons
                 bonus = 1
-                uses = 1
+                uses = 2
                 category = artillery
             }
 
@@ -5827,17 +5812,17 @@ focus_tree = {
         completion_reward = {
             add_equipment_to_stockpile = {
                 type = infantry_equipment
-                amount = 1500
+                amount = 200
                 producer = CZE
             }
             add_equipment_to_stockpile = {
 				type = artillery_equipment
-				amount = 150
+				amount = 250
 				producer = CZE
 			}
             add_equipment_to_stockpile = {
 				type = light_tank_chassis
-				amount = 75
+				amount = 100
 				producer = CZE
 			}
 
@@ -5849,7 +5834,7 @@ focus_tree = {
         icon = GFX_goal_generic_jungle_warfare
         x = -30
         y = 5
-        cost = 10
+        cost = 5
         available_if_capitulated = yes
         search_filters = {FOCUS_FILTER_RESEARCH}
         prerequisite = {
@@ -5955,7 +5940,7 @@ focus_tree = {
         icon = GFX_goal_sea_navy
         x = -17
         y = 1
-        cost = 7.2
+        cost = 10
         available_if_capitulated = yes
         search_filters = {FOCUS_FILTER_RESEARCH}
         ai_will_do = {
@@ -5970,7 +5955,7 @@ focus_tree = {
         completion_reward = {
             add_doctrine_cost_reduction = {
                 name = VEN_fleet_in_being
-                cost_reduction = 0.5
+                cost_reduction = 1
                 uses = 2
                 category = cat_fleet_in_being
             }
@@ -5985,7 +5970,7 @@ focus_tree = {
         icon = GFX_goal_generic_navy_anti_submarine
         x = -17
         y = 2
-        cost = 7.2
+        cost = 10
         available_if_capitulated = yes
         search_filters = {FOCUS_FILTER_RESEARCH}
         ai_will_do = {
@@ -6021,7 +6006,7 @@ focus_tree = {
         icon = GFX_goal_generic_navy_battleship
         x = -18
         y = 3
-        cost = 7.2
+        cost = 10
         available_if_capitulated = yes
         search_filters = {FOCUS_FILTER_RESEARCH}
         ai_will_do = {
@@ -6038,7 +6023,7 @@ focus_tree = {
                 name = VEN_battleship
                 ahead_reduction = 1
                 bonus = 1
-                uses = 1
+                uses = 2
                 category = bb_tech
             }
 
@@ -6050,7 +6035,7 @@ focus_tree = {
         icon = GFX_goal_generic_navy_carrier
         x = -16
         y = 3
-        cost = 7.2
+        cost = 10
         available_if_capitulated = yes
         search_filters = {FOCUS_FILTER_RESEARCH}
         ai_will_do = {
@@ -6067,7 +6052,7 @@ focus_tree = {
                 name = VEN_carrier
                 ahead_reduction = 1
                 bonus = 1
-                uses = 1
+                uses = 2
                 category = cv_tech
             }
 
@@ -6080,7 +6065,7 @@ focus_tree = {
         x = -1
         y = 1
         relative_position_id = VEN_carrier
-        cost = 5
+        cost = 10
         available_if_capitulated = yes
         search_filters = {FOCUS_FILTER_RESEARCH}
         ai_will_do = {
@@ -6097,13 +6082,13 @@ focus_tree = {
             add_tech_bonus = {
                 name = VEN_naval_gunnery
                 bonus = 1
-                uses = 1
+                uses = 2
                 category = naval_gunnery_tech
                 }
             add_tech_bonus = {
                 name = VEN_naval_gunnery
                 bonus = 1
-                uses = 1
+                uses = 2
 				category = naval_shell_tech
             }
 
@@ -6115,7 +6100,7 @@ focus_tree = {
         icon = GFX_goal_generic_wolf_pack
         x = -23
         y = 1
-        cost = 7.2
+        cost = 10
         available_if_capitulated = yes
         search_filters = {FOCUS_FILTER_RESEARCH}
         ai_will_do = {
@@ -6131,7 +6116,7 @@ focus_tree = {
             add_doctrine_cost_reduction = {
                 name = VEN_submarines
                 uses = 2
-                cost_reduction = 0.5
+                cost_reduction = 1
                 category = cat_trade_interdiction
             }
             custom_effect_tooltip = available_designer
@@ -6145,7 +6130,7 @@ focus_tree = {
         icon = GFX_goal_generic_navy_submarine
         x = -23
         y = 2
-        cost = 7.2
+        cost = 10
         available_if_capitulated = yes
         search_filters = {FOCUS_FILTER_RESEARCH}
         ai_will_do = {
@@ -6170,7 +6155,7 @@ focus_tree = {
         icon = GFX_goal_navy_funding
         x = -23
         y = 3
-        cost = 7.2
+        cost = 10
         available_if_capitulated = yes
         search_filters = {FOCUS_FILTER_RESEARCH}
         ai_will_do = {
@@ -6190,10 +6175,10 @@ focus_tree = {
 						include_locked = yes
 					}
 				}
-				add_extra_state_shared_building_slots = 1
+				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = dockyard
-					level = 1
+					level = 2
 				    instant_build = yes
 			    }
             }
@@ -6236,7 +6221,7 @@ focus_tree = {
         icon = GFX_goal_generic_admirality
         x = -20
         y = 4
-        cost = 7.2
+        cost = 10
         available_if_capitulated = yes
         ai_will_do = {
             factor = 10
@@ -6247,7 +6232,7 @@ focus_tree = {
             focus = VEN_battleship
         }
         completion_reward = {
-            navy_experience = 10
+            navy_experience = 25
 
 			add_ideas = SCO_idea_national_admiralty
 
@@ -6263,13 +6248,28 @@ focus_tree = {
         icon = GFX_goal_generic_bills
         x = 3
         y = 0
-        cost = 2.9
+        cost = 10
 
         ai_will_do = {
             factor = 10
         }
         completion_reward = {
-            add_political_power = 25
+            random_owned_controlled_state = {
+                add_extra_state_shared_building_slots = 2
+                add_building_construction = {
+                        type = industrial_complex
+                        level = 2
+                        instant_build = yes
+                }
+            }
+            random_owned_controlled_state = {
+                add_extra_state_shared_building_slots = 2
+                add_building_construction = {
+                        type = industrial_complex
+                        level = 2
+                        instant_build = yes
+                }
+            }
 
 
 
@@ -6284,8 +6284,7 @@ focus_tree = {
 
         search_filters = {FOCUS_FILTER_INDUSTRY FOCUS_FILTER_OIL}
         available = {
-            has_war = no
-            num_of_factories > 25
+           
         }
         prerequisite = {
             focus = VEN_expand_oil_industry
@@ -6354,7 +6353,7 @@ focus_tree = {
             }
             random_owned_controlled_state = {
                 prioritize = { 307 }
-				add_extra_state_shared_building_slots = 2
+				add_extra_state_shared_building_slots = 4
 				add_building_construction = {
 					type = steel_mill
 					level = 2
@@ -6362,7 +6361,7 @@ focus_tree = {
 				}
                 add_building_construction = {
                     type = industrial_complex
-                    level = 1
+                    level = 2
                     instant_build = yes
                 }
             }
@@ -6426,6 +6425,14 @@ focus_tree = {
             factor = 10
         }
         completion_reward = {
+            random_owned_controlled_state = {
+                add_extra_state_shared_building_slots = 2
+                add_building_construction = {
+                    type = industrial_complex
+                    level = 2
+                    instant_build = yes
+                }
+            }
             add_tech_bonus = {
                 name = VEN_improve_living_standards
                 bonus = 1
@@ -6450,6 +6457,15 @@ focus_tree = {
             factor = 10
         }
         completion_reward = {
+            random_owned_controlled_state = {
+                
+                add_extra_state_shared_building_slots = 1
+                add_building_construction = {
+                    type = industrial_complex
+                    level = 1
+                    instant_build = yes
+                }
+            }
             add_tech_bonus = {
                 name = VEN_industrial_development
                 bonus = 1
@@ -6539,7 +6555,7 @@ focus_tree = {
             }
             add_resource = {
                 type = oil
-                amount = 2
+                amount = 5
                 state = 948
             }
 
@@ -6563,6 +6579,14 @@ focus_tree = {
             factor = 10
         }
         completion_reward = {
+            random_owned_controlled_state = {
+                add_extra_state_shared_building_slots = 2
+                add_building_construction = {
+                        type = industrial_complex
+                        level = 2
+                        instant_build = yes
+                }
+            }
             swap_ideas = {
                 remove_idea = VEN_oil_7
                 add_idea = VEN_oil_8
@@ -6660,7 +6684,7 @@ focus_tree = {
         icon = GFX_goal_generic_positive_trade_relations
         x = 0
         y = 4
-        cost = 7.2
+        cost = 5
 
         search_filters = {FOCUS_FILTER_POLITICAL FOCUS_FILTER_INDUSTRY}
         prerequisite = {
@@ -6693,8 +6717,7 @@ focus_tree = {
         icon = GFX_goal_generic_construct_infrastructure
         x = -2
         y = 4
-        cost = 7.2
-
+        cost = 5
         search_filters = {FOCUS_FILTER_INDUSTRY}
         prerequisite = {
             focus = VEN_open_rubber_plantations
@@ -6710,10 +6733,19 @@ focus_tree = {
 			}
             random_owned_controlled_state = {
                 prioritize = { 489 }
-                add_extra_state_shared_building_slots = 1
+                add_extra_state_shared_building_slots = 2
                 add_building_construction = {
                     type = infrastructure
-                    level = 1
+                    level = 2
+                    instant_build = yes
+                }
+            }
+            random_owned_controlled_state = {
+                prioritize = { 307 }
+                add_extra_state_shared_building_slots = 2
+                add_building_construction = {
+                    type = infrastructure
+                    level = 2
                     instant_build = yes
                 }
             }
@@ -6737,6 +6769,14 @@ focus_tree = {
             factor = 10
         }
         completion_reward = {
+            random_owned_controlled_state = {
+                add_extra_state_shared_building_slots = 2
+                add_building_construction = {
+                        type = industrial_complex
+                        level = 2
+                        instant_build = yes
+                }
+            }
             swap_ideas = {
                 remove_idea = VEN_oil_9
                 add_idea = VEN_oil_10
@@ -6813,19 +6853,19 @@ focus_tree = {
         completion_reward = {
             random_owned_controlled_state = {
                 prioritize = { 489 }
-                add_extra_state_shared_building_slots = 1
+                add_extra_state_shared_building_slots = 2
                 add_building_construction = {
                     type = arms_factory
-                    level = 1
+                    level = 2
                     instant_build = yes
                 }
             }
             random_owned_controlled_state = {
                 prioritize = { 488 }
-                add_extra_state_shared_building_slots = 1
+                add_extra_state_shared_building_slots = 2
                 add_building_construction = {
                     type = arms_factory
-                    level = 1
+                    level = 2
                     instant_build = yes
                 }
             }
@@ -6867,7 +6907,7 @@ focus_tree = {
         icon = GFX_goal_VEN_air_force
         x = -9
         y = 0
-        cost = 5
+        cost = 10
         available_if_capitulated = yes
         ai_will_do = {
             factor = 10
@@ -6877,7 +6917,7 @@ focus_tree = {
             add_doctrine_cost_reduction = {
                 name = VEN_a_seprate_branch
                 uses = 2
-                cost_reduction = 0.5
+                cost_reduction = 1
                 category = air_doctrine
             }
         }
@@ -6903,7 +6943,7 @@ focus_tree = {
         completion_reward = {
             add_tech_bonus = {
                 name = VEN_fighters
-                bonus = 0.5
+                bonus = 1
                 uses = 2
                 category = light_fighter
             }
@@ -6963,7 +7003,7 @@ focus_tree = {
         icon = GFX_goal_generic_airport
         x = -9
         y = 2
-        cost = 7.2
+        cost = 10
         available_if_capitulated = yes
         prerequisite = {
             focus = VEN_fighters
@@ -6973,6 +7013,12 @@ focus_tree = {
             factor = 10
         }
         completion_reward = {
+            add_tech_bonus = {
+                name = VEN_fighters
+                bonus = 1
+                uses = 1
+                category = air_equipment
+            }
             random_owned_controlled_state = {
                 prioritize = { 307 }
 				add_building_construction = {

--- a/common/national_focus/yugoslavia.txt
+++ b/common/national_focus/yugoslavia.txt
@@ -4536,7 +4536,7 @@ focus_tree = {
 		id = YUG_develop_civilian_industry
 		icon = GFX_goal_generic_construct_civ_factory
 		prerequisite = { focus = YUG_expand_the_mining_industry }
-		mutually_exclusive = { focus = YUG_develop_military_industry }
+		
 		x = -1
 		y = 1
 		relative_position_id = YUG_expand_the_mining_industry
@@ -4742,10 +4742,10 @@ focus_tree = {
 				limit = {
 					ROOT = { has_full_control_of_state = PREV }
 				}
-				add_extra_state_shared_building_slots = 1
+				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = industrial_complex
-					level = 1
+					level = 2
 					instant_build = yes
 				}
 			}
@@ -5001,7 +5001,7 @@ focus_tree = {
 		id = YUG_develop_military_industry
 		icon = GFX_goal_generic_construct_mil_factory
 		prerequisite = { focus = YUG_expand_the_mining_industry }
-		mutually_exclusive = { focus = YUG_develop_civilian_industry }
+		
 		x = 1
 		y = 1
 		relative_position_id = YUG_expand_the_mining_industry

--- a/common/technologies/MTG_naval_Support.txt
+++ b/common/technologies/MTG_naval_Support.txt
@@ -1943,7 +1943,7 @@ technologies = {
 			research_cost_coeff = 1
 		}
 
-		research_cost = 1.5
+		research_cost = 0.0001
 		start_year = 1922
 
 		folder = {

--- a/events/BEL_events.txt
+++ b/events/BEL_events.txt
@@ -827,14 +827,15 @@ country_event = {
 	option = {
 		name = tblra.28.a
 		ai_chance = {
-			factor = 30
+			factor = 100
 		}
 		BEL = { puppet = HOL }
+		BEL = { puppet = INS }
 	}
 	
 	option = {
 		name = tblra.28.b
-		ai_chance = { factor = 10 }
+		ai_chance = { factor = 0 }
 		trigger = {
 			HOL = {
 				is_puppet = no
@@ -864,7 +865,7 @@ country_event = {
 	
 	option = {
 		name = tblra.28.c
-		ai_chance = { factor = 60 }
+		ai_chance = { factor = 0 }
 		BEL = {
 			declare_war_on = {
 				target = HOL

--- a/events/Estonia.txt
+++ b/events/Estonia.txt
@@ -224,3 +224,32 @@ country_event = {
 		}
 	}
 }
+country_event = {
+	id = est.19
+	title = est.19.t
+	desc = est.19.d
+	picture = GFX_report_event_generic_parliament
+	
+	is_triggered_only = yes
+
+	option = { # Accept
+		name = est.19.a
+		ai_chance = { factor = 99 }
+		EST = { 
+			annex_country = { target = ROOT transfer_troops = yes }
+			
+		}
+		
+	}
+
+	option = { # Decline
+		name = est.19.b 
+		ai_chance = { factor = 0.5 }
+		EST = { 
+			create_wargoal = {
+				type = annex_everything
+				target = ROOT
+			}	
+		}		
+	}
+}

--- a/events/Finland.txt
+++ b/events/Finland.txt
@@ -3242,6 +3242,7 @@ news_event = {
 	}
 }
 
+
 # Options and results are now hard coded to doing focuses. 
 # Election of 1937: Svinhufvund vs Kallio
 country_event = { #Kallio being leader moved to doing focuses instead of dates fyi

--- a/events/MTG_NewsEvents.txt
+++ b/events/MTG_NewsEvents.txt
@@ -523,6 +523,8 @@ news_event = {
 				original_tag = RAJ
 				original_tag = AST
 				original_tag = NZL
+				original_tag = EGY
+				original_tag = MAL
 			}
 		}
 	}
@@ -539,6 +541,8 @@ news_event = {
 						original_tag = RAJ
 						original_tag = AST
 						original_tag = NZL
+						original_tag = EGY
+						original_tag = MAL
 					}
 				}
 			}

--- a/events/egypt.txt
+++ b/events/egypt.txt
@@ -2502,3 +2502,16 @@ country_event = { #
 		
     }
 }
+country_event = { # Embrace Enlgish Leadership
+    id = egypt.67
+    picture = GFX_report_event_EGY_fuad
+	title = egypt.67.t
+	desc = egypt.67.d
+    fire_only_once = yes
+    is_triggered_only = yes
+
+    option = { # Yes
+       	name = egypt.67.a
+		   ENG = { add_ideas = EGY_British_Acceptance }
+    } 
+}

--- a/events/venezuela.txt
+++ b/events/venezuela.txt
@@ -642,7 +642,7 @@ country_event = { # Fate of Jimenez Event
     ai_chance = {
         base = 0
     }
-    add_stability = 0.05
+    add_stability = 0.1
     }
     option = {
     name = venezuela.23.b

--- a/history/countries/PAK - Pakistan.txt
+++ b/history/countries/PAK - Pakistan.txt
@@ -18,6 +18,9 @@ set_war_support = 0.3
 set_stability = 0.4 
 set_research_slots = 4
 set_convoys = 20
+add_ideas = {
+	RAJ_Caste_Debuff_1
+}
 if = {
 	limit = {
 		has_dlc = "Battle for the Bosporus"

--- a/history/states/584-Turkmenistan.txt
+++ b/history/states/584-Turkmenistan.txt
@@ -11,7 +11,7 @@ state={
 		owner = SOV
 		buildings = {
 			infrastructure = 1
-			industrial_complex = 1
+			
 
 		}
 		victory_points = {

--- a/history/states/838-Illubabor.txt
+++ b/history/states/838-Illubabor.txt
@@ -25,9 +25,9 @@ state={
 
 		}
 		buildings = {
-			industrial_complex = 1
+			
 			infrastructure = 1
-			arms_factory = 1
+			
 		}
 		victory_points = {
 			13293 2 

--- a/history/states/839-Welega.txt
+++ b/history/states/839-Welega.txt
@@ -22,9 +22,9 @@ state={
 
 		}
 		buildings = {
-			industrial_complex = 1
-			infrastructure = 1
-			arms_factory = 1
+			
+			
+			
 		}
 		victory_points = {
 			2009 2 

--- a/history/states/908-Afar.txt
+++ b/history/states/908-Afar.txt
@@ -17,9 +17,9 @@ state={
 
 		}
 		buildings = {
-			infrastructure = 2
-			arms_factory = 1
-			industrial_complex = 2
+			infrastructure = 1
+			
+			industrial_complex = 1
 
 
 		}

--- a/history/states/973-Andorra.txt
+++ b/history/states/973-Andorra.txt
@@ -7,14 +7,14 @@ state={
 	state_category = rural
 
 	history={
-		owner = FRA
-		add_core_of = FRA
+		owner = SPR
+		add_core_of = SPR
 		victory_points = {
 			3898 3
 		}
 		buildings = {
 			infrastructure = 2
-			industrial_complex = 1
+			industrial_complex = 2
 		}
 	}
 

--- a/localisation/english/AFG_l_english.yml
+++ b/localisation/english/AFG_l_english.yml
@@ -74,3 +74,5 @@
  AFG_modernize_cavalry_desc:0 ""
  AFG_import_soviet_tank_designs:0 "Import [SOV.GetAdjective] Tank Designs"
  AFG_import_soviet_tank_designs_desc:0 ""
+ AFG_invest_in_steel:0 "Invest in steel"
+ AFG_invest_in_steel_desc:0 "We must invest in our steel industries"

--- a/localisation/english/BEL_l_english.yml
+++ b/localisation/english/BEL_l_english.yml
@@ -202,7 +202,8 @@
  COG_idea_war_mining_production_directorate:0 "War Mining Production Directorate"
  COG_idea_war_mining_production_directorate2:0 "War Mining Production Directorate"
  COG_idea_war_mining_production_directorate3:0 "War Mining Production Directorate"
- 
+
+ tblra_Economic_Boom_of_Antwerp:0 "Economic Boom of Antwerp"
  tblra_linguistic_question_in_military:0 "Linguistic Military Question"
  tblra_linguistic_question_in_military_desc:0 "For years the Flemish movement wanted to split the army on linguistic bases, arguing that Flemish soldiers couldn't understand orders given in French."
  tblra_divide_the_military:0 "Reorganize the Army Linguistically"
@@ -490,7 +491,10 @@
  tblra_restore_constitution:0 "Restore the Constitution"
  tblra_restore_constitution_desc:0 "After a series of troubles comparable to the Flood of Noah, the dove of peace has finally returned to the ark of the fatherland. While the clouds are drifting on the horizon, it may be time to step aside and restore the constitution, the rainbow between the government and the citizens. With the restoration of the rule of law, power has been returned to the hands of a civilian government."
  tblra_aa_expertise:0 "AA Guns Manufacturing Expertise"
- 
+
+
+ tblra_attack_Luxemburg:0 "Attack Luxemburg"
+ tblra_attack_Luxemburg_desc:0 "The people of Belgium vote to integrate Luxemburg"
  tblra_national_union:0 "Wartime Political Union"
  tblra_national_union_desc:0 "Due to the war, a new coalition government was established to unite the democratic parties against the foreign threat."
  tblra_peacetime_national_union:0 "National Union Government" 

--- a/localisation/english/COL_l_english.yml
+++ b/localisation/english/COL_l_english.yml
@@ -31,7 +31,7 @@
  COL_liberty_ethos_desc:0 "Alfonso López Pumarejo launched many economic and social reforms that have been nicknamed the Revolución en Marcha, or Marching Revolution."
  ###
 
-
+ COL_Reforming_the_Education_System:0 "Reforming the Education System"
  COL_raspar_olla:0 "Extractivist Lobbyist"
  COL_tupac_amaru:0 "Legacy of Tupac Amaru"
  COL_yarumos_idea:0 "Yarumos"

--- a/localisation/english/EGY_l_english.yml
+++ b/localisation/english/EGY_l_english.yml
@@ -303,7 +303,8 @@
  EGY_support_womens_suffrage_desc:0 ""
  EGY_placate_the_army:0 "Placate the Army"
  EGY_placate_the_army_desc:0 ""
-
+ EGY_Embrace_English_Leadership:0 "Embrace English Leadership"
+ EGY_Embrace_English_Leadership_desc:0 "The United Kingdom has shown the citizens of Egypt that they can trust them, now is the time we fully embrace them"
  #nasser
 
  EGY_the_free_officers_movement:0 "Coup the King"
@@ -1005,6 +1006,12 @@
  egypt.66.t:0 "[GER.GetNameDefCap] refuses to send us advisors"
  egypt.66.d:0 "[GER.GetNameDefCap] has refused to send us a military mission to us to us to advise our army and support the modernisation and traning of it. It is unlikley to expect further cooperation from [GER.GetNameDef] in the future."
  egypt.66.a:0 "We're just pawns to the [GER.GetAdjective]s."
+
+ egypt.67.t:0 "Egypt's Embracement"
+ egypt.67.d:0 "The people of Egypt fully embrace in the United Kingdom's rule, they shall be rewarded for this."
+ egypt.67.a:0 "They shall prosper"
+
+
 
  #traits
 

--- a/localisation/english/EST_l_english.yml
+++ b/localisation/english/EST_l_english.yml
@@ -242,3 +242,9 @@
  EST_jaan_flag:0 "Jaan Tõnisson Has Won the Election"
  EST_mae_flag:0 "Hajlmar Mae Has Won the Election"
  EST_sare_flag:0 "Karl Säre Has Won the Election"
+
+ # Events
+ est.19.t:0 "Unify the Baltics"
+ est.19.d:0 "The nation of Estonia invites us to fully combine our nations"
+ est.19.a:0 "We accept the unification of the Baltics"
+ est.19.b:0 "We cannot accept this blasphemous offer"

--- a/localisation/english/FIN_l_english.yml
+++ b/localisation/english/FIN_l_english.yml
@@ -731,3 +731,5 @@
 
  FIN_generic_head_of_intelligence:0 "Reino Hallamaa"
  FIN_Jukka_lehtosaari:0 "Jukka Lehtosaari"
+ fin_Finnish_Swedish_Defense_Pact:0 "Finnish-Swedish Defense Pact"
+ fin_Finnish_Swedish_Industrial_Pact:0 "Finnish-Swedish Industrial Pact"

--- a/localisation/english/IRQ_l_english.yml
+++ b/localisation/english/IRQ_l_english.yml
@@ -271,6 +271,8 @@
   IRQ_ally_the_turkish_communists_desc:0 "As the Turks did their own revolution, it could be useful to ally them."
   IRQ_ally_the_iranian_communists:0 "Ally the Iranian Communists?"
   IRQ_ally_the_iranian_communists_desc:0 "As the Iranians did their own revolution, it could be useful to ally them."
+  IRQ_invest_in_steel:0 "Invest in Steel"
+  IRQ_invest_in_steel_desc:0 "We must invest in our steel industries"
 
   IRQ_assimilate_arabistan:0 "Assimilate Arabistan"
 

--- a/localisation/english/PER_l_english.yml
+++ b/localisation/english/PER_l_english.yml
@@ -244,6 +244,8 @@
  PER_increase_research_funds_desc:0 "[PER.GetAdjective] scientists and intellectuals deserve much more then a current leftover of the budget. Increasing the educational and research spending will significantly improve our technological development. "
  PER_Military_Spend_Increase:0 "Military Spend Increase"
  PER_taslihat_e_artesh:0 "Taslihat-e Artesh"
+ PER_invest_in_steel:0 "Invest in Steel"
+ PER_invest_in_steel_desc:0 "We must invest in our steel industries"
 
  #build in 1938 and managed by the British
  PER_generic_light_aircraft_manufacturer:0 "Doshan Tappeh Factory"

--- a/localisation/english/SAU_l_english.yml
+++ b/localisation/english/SAU_l_english.yml
@@ -228,6 +228,8 @@
  SAU_east_destabilized:0 "Destabilizing the Middle-East"
  SAU_claim:0 "Saudi Expansionism"
  SAU_integrate_kuwait:0 "Integrate Kuwait"
+ SAU_invest_in_steel:0 "Invest in steel"
+ SAU_invest_in_steel_desc:0 "We must invest in our steel industries"
  
  SAU_camelry_expertise:0 "Camelry Expertise"
  SAU_camelry_expertise_desc:0 "The Arabs have travelled the desert for centuries, and for centuries they have fought alongside their trusty camels."

--- a/map/adjacencies.csv
+++ b/map/adjacencies.csv
@@ -232,8 +232,7 @@ From;To;Type;Through;start_x;start_y;stop_x;stop_y;adjacency_rule_name;Comment
 3915;3899;impassable;-1;-1;-1;-1;-1;;franco spain
 3915;3898;impassable;-1;-1;-1;-1;-1;;franco spain
 6931;3898;impassable;-1;-1;-1;-1;-1;;franco spain
-
-
+6915;3898;impassable;-1;-1;-1;-1;-1;;franco spain
 
 3314;6336;sea;2752;2885;1578;2890;1581;;Afsluitdijk
 13268;3988;sea;6801;-1;-1;-1;-1;;Corinth Canal


### PR DESCRIPTION
- Balanced Argentina's ideas and focuses. Path that can choose to help USA or UK now gives Ideas to you and that particular nation.
- Balanced Belgium's ideas and focuses. Path's that flip you non-historically now are easier to go, such as communist path. Fixed the path that puppets the Netherland's also takes the Dutch East Indies.
- Fixed some errors that were happening with Ethiopia.
- Andorra is annexed to Spain, and the impassable terrain extends 1 more tile.
- Balanced Chile's ideas and focuses. Made a naval designer for Chile.
- Balanced Brazil's ideas and focuses. 
- Balanced Bulgaria's ideas and focuses. Removed some weird requirements such as Excavation 4 to do a focus.
- Balanced Canada's ideas and focuses. Base game Canada got a couple focus changes and time changes. RT56 Canada also got some changes.
- Balanced Denmark's ideas and focuses. Denmark had an idea that gave construction speed and research bonuses to Russia, but now it gives those bonuses to themselves as well.
- Balanced Colombia's ideas and focuses. Had a couple focuses that would give you 5 army experience and it would cost 70 days to do.
- Balanced Czechoslovakia's focus tree. Not many changes, just made it so it goes down its industry tree first if it's an AI, and fixed some infrastructure focuses, so it does what is intended.
- Balanced Egypt's ideas and industry tree. More specifically the path that keeps them allied to UK got some bonuses.
-  Balanced Estonia's ideas and industry tree. Can now take a path to annex the other Baltic nations and core them through an event.
- Changed the Mughal formable so it doesn't give the unifications debuffs to Pakistan.
- Balanced Finland's ideas and focuses. The path that sides with Sweden now gives a bonus to both nations if they are in a faction. The path that annexes Scandinavia now removes the Scandinavia Unified buff. Also the nation now gets unification debuffs when it does that formable.
- Balanced Hungary's ideas and focuses. The Gyor Program now gives extra bonuses.
- Balanced Greece's ideas and focuses. The Revive the Byzantine focus now isn't 140 days to complete. Also changed it so the Bedrock of Balkan Financial Stability focus gives one more factory.
- Balanced Iraq's ideas and focuses. Simple focus time changes and things you get from the focuses.
- Balanced Honduras's focus tree. Fixed their air bonuses, and changed focus times for some nations.
- Balanced Indonesia's focus tree. Fixed their air bonuses, and changed around some focuses.
- Balanced Mexico's focus tree. Fixed some focuses so they do what is intended.
- Balanced Netherland's focus tree. Removed commented out bonuses that didn't make sense to be commented out.
- Balanced Romania's focus tree. Removed the annexation of all the Balkan nations, they are now war goals and require less manpower to complete. My idea is to that hopefully the Axis doesn't only consist of 3 players Germany, Italy, and Romania. Hopefully this adds more variety to factions.
- Changed Army Financing. Now gives Dockyard Construction Speed.
- Balanced Iran's ideas and focus tree. They now get Industrial Boom generic focus tree, also gets a steel focus which helps the issue that Middle Eastern nations have no steel which really hurts their economy and military.
- Balanced Saudi Arabia's ideas and focus tree. They get more bonuses for infantry and they also get a steel focus.
- Balanced Afghanistan's focus tree.  They also get a steel focus. 
- Balanced Italy's focus tree. Changed around a couple focus times and bonuses. Also removed the Mutually exclusive in their industry tree, so they can do both focuses, which adds a little more industry to that nation.
- Fixed an issue with Turkey's base game tree. The steel industry focus now gives it to Turkey and not a random state on the map.
- Balanced Norway's ideas and focus tree. Fixed air bonuses and an upgrade to their industry tree. 
- Balanced Colombia's ideas and focus tree. Not too much happened here just an extra 2% factory and dockyard output.
- Balanced the new Soviet tree. Now the event doesn't give them factory conversion speed, it does what is intended. Basically removes the meta to convert all your Mils to Civs absurdly fast.
- Changed a Scotland idea that was tied to Venezuela.
- Balanced Siam's focus tree. Changed around a couple focuses.
- Balanced USA's focus tree. Just changed one of the CAS bonuses to air_equipment so they could use it on engines or guns. They had no bonuses in their tree that did that, so it is a helpful change.
- Balanced Yugoslavia's focus tree. Removed the mutually exclusive in their industry tree. 

These are not changes that need to be added right away. I want you to look over them and tell me some things need to be changed, or if I should do more changes as well to either the same countries or other countries.