### PR TITLE
Heavy cannons resources

### DIFF
--- a/common/characters/GER.txt
+++ b/common/characters/GER.txt
@@ -1208,7 +1208,7 @@ characters={
 			}
 		}
 		advisor={
-			cost = 100
+			cost = 75
 			slot = theorist
 			idea_token = von_braun
 			ledger = air
@@ -1216,7 +1216,7 @@ characters={
 				original_tag = GER
 			}
 			research_bonus = {
-				rocketry = 0.150
+				rocketry = 0.25
 			}
 			traits = {
 				rocket_scientist
@@ -1232,7 +1232,7 @@ characters={
 			}
 		}
 		advisor={
-			cost = 100
+			cost = 75
 			slot = theorist
 			idea_token = heisenberg
 			ledger = army
@@ -1661,7 +1661,7 @@ characters={
 				original_tag = GER
 			}
 			traits = {
-				navy_anti_submarine_1
+				navy_submarine_2
 			}
 			cost =  50
 			ai_will_do = {

--- a/common/country_leader/00_traits.txt
+++ b/common/country_leader/00_traits.txt
@@ -1,14 +1,15 @@
 @tier1 = 30
 @tier2 = 20
 @tier3 = 10
+
 @experience_gain_low = 0.03
 @experience_gain_medium = 0.06
 @experience_gain_high = 0.08
 
-#@experience_gain_low = 0.20
-#@experience_gain_medium = 0.30
-#@experience_gain_high = 0.40
-@experience_gain_high_old_guard = 0.15
+@chief_experience_gain_low = 0.30
+@chief_experience_gain_medium = 0.40
+@chief_experience_gain_high = 0.50
+@chief_experience_gain_high_old_guard = 0.15
 ###Todo remove commented advisor experience gains
 
 leader_traits = {
@@ -1037,7 +1038,7 @@ leader_traits = {
 	red_army_organizer = { # Trotsky's trait if invited to join the Mexican government. Combines effects of Genius Army Organizer and Communist Revolutionary
 		sprite = 12
 		army_org_factor = 0.12
-		experience_gain_army = @experience_gain_high
+		experience_gain_army = @chief_experience_gain_high
 		communism_drift = 0.1
 
 		command_cap = @tier3
@@ -3105,7 +3106,7 @@ leader_traits = {
 	SWI_commander_in_chief = { 
 		random = no
 		sprite = 5
-		experience_gain_army = @experience_gain_high
+		experience_gain_army = @chief_experience_gain_high
 		army_defence_factor = 0.15
 		command_power_gain = 0.07
 		command_cap = @tier3
@@ -5878,13 +5879,13 @@ leader_traits = {
 		random = no
 		equipment_bonus = {
 			carrier = {
-				build_cost_ic = 0.1
+				build_cost_ic = 0.2
 			}
 			capital_ship = {
-				build_cost_ic = 0.1
+				build_cost_ic = 0.2
 			}
 			screen_ship = {
-				build_cost_ic = 0.1
+				build_cost_ic = 0.2
 			}
 			submarine = {
 				build_cost_ic = -0.15 sub_visibility = -0.1 surface_visibility = -0.1 naval_speed = 0.15 naval_range = 0.1
@@ -6225,7 +6226,7 @@ leader_traits = {
 	army_chief_defensive_1 = { # +5 Defensive efficiency
 		sprite = 9
 		army_defence_factor = 0.05
-		experience_gain_army = @experience_gain_low
+		experience_gain_army = @chief_experience_gain_low
 
 		command_cap = @tier1
 
@@ -6237,7 +6238,7 @@ leader_traits = {
 	army_chief_defensive_2 = { # +10 Defensive efficiency
 		sprite = 9
 		army_defence_factor = 0.1
-		experience_gain_army = @experience_gain_medium
+		experience_gain_army = @chief_experience_gain_medium
 
 		command_cap = @tier2
 
@@ -6249,7 +6250,7 @@ leader_traits = {
 	army_chief_defensive_3 = { # +15 Defensive efficiency
 		sprite = 9
 		army_defence_factor = 0.15
-		experience_gain_army = @experience_gain_high
+		experience_gain_army = @chief_experience_gain_high
 
 		command_cap = @tier3
 
@@ -6262,7 +6263,7 @@ leader_traits = {
 	army_chief_offensive_1 = { # +5 Offensive efficiency
 		sprite = 7
 		army_attack_factor = 0.05
-		experience_gain_army = @experience_gain_low
+		experience_gain_army = @chief_experience_gain_low
 
 		command_cap = @tier1
 
@@ -6274,7 +6275,7 @@ leader_traits = {
 	army_chief_offensive_2 = { # +10 Offensive efficiency
 		sprite = 7
 		army_attack_factor = 0.1
-		experience_gain_army = @experience_gain_medium
+		experience_gain_army = @chief_experience_gain_medium
 
 		command_cap = @tier2
 
@@ -6286,7 +6287,7 @@ leader_traits = {
 	army_chief_offensive_3 = { # +15 Offensive efficiency
 		sprite = 7
 		army_attack_factor = 0.15
-		experience_gain_army = @experience_gain_high
+		experience_gain_army = @chief_experience_gain_high
 
 		command_cap = @tier3
 
@@ -6297,7 +6298,7 @@ leader_traits = {
 
 	army_chief_old_guard = { # Rate at which field experience is gained decreases by 10%
 		sprite = 18 # Should not need sprite, should mostly be secondary
-		experience_gain_army = @experience_gain_high_old_guard
+		experience_gain_army = @chief_experience_gain_medium
 		max_command_power = 25
 		political_power_factor = 0.075
 
@@ -6309,7 +6310,7 @@ leader_traits = {
 	army_chief_drill_1 = { # Decreases training time for ground units
 		sprite = 18
 		training_time_army_factor = -0.05
-		experience_gain_army = @experience_gain_low
+		experience_gain_army = @chief_experience_gain_low
 
 		command_cap = @tier1
 		
@@ -6321,7 +6322,7 @@ leader_traits = {
 	army_chief_drill_2 = { # Decreases training time for ground units
 		sprite = 18
 		training_time_army_factor = -0.1
-		experience_gain_army = @experience_gain_medium
+		experience_gain_army = @chief_experience_gain_medium
 
 		command_cap = @tier2
 
@@ -6333,7 +6334,7 @@ leader_traits = {
 	army_chief_drill_3 = { # Decreases training time for ground units
 		sprite = 18
 		training_time_army_factor = -0.15
-		experience_gain_army = @experience_gain_high
+		experience_gain_army = @chief_experience_gain_high
 
 		command_cap = @tier3
 		
@@ -6345,7 +6346,7 @@ leader_traits = {
 
 	army_chief_reform_1 = {
 		sprite = 19
-		experience_gain_army = @experience_gain_low
+		experience_gain_army = @chief_experience_gain_low
 		experience_gain_army_factor = 0.05
 
 		command_cap = @tier1
@@ -6357,7 +6358,7 @@ leader_traits = {
 
 	army_chief_reform_2 = {
 		sprite = 19
-		experience_gain_army = @experience_gain_medium
+		experience_gain_army = @chief_experience_gain_medium
 		experience_gain_army_factor = 0.1
 
 		command_cap = @tier2
@@ -6369,7 +6370,7 @@ leader_traits = {
 
 	army_chief_reform_3 = {
 		sprite = 19
-		experience_gain_army = @experience_gain_high
+		experience_gain_army = @chief_experience_gain_high
 		experience_gain_army_factor = 0.15
 
 		command_cap = @tier3
@@ -6383,7 +6384,7 @@ leader_traits = {
 	army_chief_organizational_1 = { # Ground units get 4 more Organization
 		sprite = 5
 		army_org_factor = 0.04
-		experience_gain_army = @experience_gain_low
+		experience_gain_army = @chief_experience_gain_low
 
 		command_cap = @tier1
 
@@ -6395,7 +6396,7 @@ leader_traits = {
 	army_chief_organizational_2 = { # Ground units get 8 more Organization
 		sprite = 5
 		army_org_factor = 0.08
-		experience_gain_army = @experience_gain_medium
+		experience_gain_army = @chief_experience_gain_medium
 
 		command_cap = @tier2
 
@@ -6407,7 +6408,7 @@ leader_traits = {
 	army_chief_organizational_3 = { # Ground units get 12 more Organization
 		sprite = 5
 		army_org_factor = 0.12
-		experience_gain_army = @experience_gain_high
+		experience_gain_army = @chief_experience_gain_high
 
 		command_cap = @tier3
 
@@ -6419,7 +6420,7 @@ leader_traits = {
 	army_chief_planning_1 = { #
 		sprite = 12
 		planning_speed = 0.05
-		experience_gain_army = @experience_gain_low
+		experience_gain_army = @chief_experience_gain_low
 
 		command_cap = @tier1
 
@@ -6431,7 +6432,7 @@ leader_traits = {
 	army_chief_planning_2 = { #
 		sprite = 12
 		planning_speed = 0.10
-		experience_gain_army = @experience_gain_medium
+		experience_gain_army = @chief_experience_gain_medium
 		
 		command_cap = @tier2
 		
@@ -6443,7 +6444,7 @@ leader_traits = {
 	army_chief_planning_3 = { #
 		sprite = 12
 		planning_speed = 0.15
-		experience_gain_army = @experience_gain_high
+		experience_gain_army = @chief_experience_gain_high
 		
 		command_cap = @tier3
 		
@@ -6456,7 +6457,7 @@ leader_traits = {
 		sprite = 12
 		out_of_supply_factor = -0.03		
 		army_morale_factor = 0.04
-		experience_gain_army = @experience_gain_low
+		experience_gain_army = @chief_experience_gain_low
 		
 		command_cap = @tier1
 		
@@ -6469,7 +6470,7 @@ leader_traits = {
 		sprite = 12
 		out_of_supply_factor = -0.06		
 		army_morale_factor = 0.08
-		experience_gain_army = @experience_gain_medium
+		experience_gain_army = @chief_experience_gain_medium
 		
 		command_cap = @tier2
 		
@@ -6482,7 +6483,7 @@ leader_traits = {
 		sprite = 12
 		out_of_supply_factor = -0.09
 		army_morale_factor = 0.12
-		experience_gain_army = @experience_gain_high
+		experience_gain_army = @chief_experience_gain_high
 		
 		command_cap = @tier3
 		
@@ -6495,7 +6496,7 @@ leader_traits = {
 	army_chief_maneuver_1 = { # Ground units move 5% faster
 		sprite = 5
 		army_speed_factor = 0.05
-		experience_gain_army = @experience_gain_low
+		experience_gain_army = @chief_experience_gain_low
 
 		command_cap = @tier1
 		
@@ -6507,7 +6508,7 @@ leader_traits = {
 	army_chief_maneuver_2 = { # Ground units move 10% faster
 		sprite = 5
 		army_speed_factor = 0.1
-		experience_gain_army = @experience_gain_medium
+		experience_gain_army = @chief_experience_gain_medium
 
 		command_cap = @tier2
 		
@@ -6519,7 +6520,7 @@ leader_traits = {
 	army_chief_maneuver_3 = { # Ground units move 15% faster
 		sprite = 5
 		army_speed_factor = 0.15
-		experience_gain_army = @experience_gain_high
+		experience_gain_army = @chief_experience_gain_high
 
 		command_cap = @tier3
 
@@ -6532,7 +6533,7 @@ leader_traits = {
 		sprite = 5
 		max_dig_in = 3
 		mobilization_speed = -0.02
-		experience_gain_army = @experience_gain_low
+		experience_gain_army = @chief_experience_gain_low
 		
 		command_cap = @tier1
 		
@@ -6545,7 +6546,7 @@ leader_traits = {
 		sprite = 5
 		max_dig_in = 5
 		mobilization_speed = -0.04
-		experience_gain_army = @experience_gain_medium
+		experience_gain_army = @chief_experience_gain_medium
 
 		command_cap = @tier2
 		
@@ -6558,7 +6559,7 @@ leader_traits = {
 		sprite = 5
 		max_dig_in = 7
 		mobilization_speed = -0.06
-		experience_gain_army = @experience_gain_high
+		experience_gain_army = @chief_experience_gain_high
 
 		command_cap = @tier3
 		
@@ -6571,7 +6572,7 @@ leader_traits = {
 	army_entrenchment_1 = { # Ground units entrench n% faster
 		sprite = 9
 		dig_in_speed_factor = 0.08
-		experience_gain_army = @experience_gain_low
+		#experience_gain_army = @chief_experience_gain_low
 
 		command_cap = @tier1
 		
@@ -6583,7 +6584,7 @@ leader_traits = {
 	army_entrenchment_2 = { # Ground units entrench 8% faster
 		sprite = 9
 		dig_in_speed_factor = 0.16
-		experience_gain_army = @experience_gain_medium
+		#experience_gain_army = @chief_experience_gain_medium
 
 		command_cap = @tier2
 		
@@ -6595,7 +6596,7 @@ leader_traits = {
 	army_entrenchment_3 = { # Ground units entrench 12% faster
 		sprite = 9
 		dig_in_speed_factor = 0.24
-		experience_gain_army = @experience_gain_high
+		#experience_gain_army = @chief_experience_gain_high
 
 		command_cap = @tier3
 		
@@ -6609,7 +6610,7 @@ leader_traits = {
 		sprite = 8
 		army_armor_attack_factor = 0.05
 	    army_armor_defence_factor = 0.05
-		experience_gain_army = @experience_gain_low
+		#experience_gain_army = @chief_experience_gain_low
 
 		command_cap = @tier1
 		
@@ -6622,7 +6623,7 @@ leader_traits = {
 		sprite = 8
 		army_armor_attack_factor = 0.1
 	    army_armor_defence_factor = 0.1
-		experience_gain_army = @experience_gain_medium
+		#experience_gain_army = @chief_experience_gain_medium
 
 		command_cap = @tier2
 		
@@ -6635,7 +6636,7 @@ leader_traits = {
 		sprite = 8
 		army_armor_attack_factor = 0.15
 	    army_armor_defence_factor = 0.15
-		experience_gain_army = @experience_gain_high
+		#experience_gain_army = @chief_experience_gain_high
 
 		command_cap = @tier3
 		
@@ -6649,7 +6650,7 @@ leader_traits = {
 		sprite = 16
 		army_artillery_attack_factor = 0.1
 		army_artillery_defence_factor = 0.05
-		experience_gain_army = @experience_gain_low
+		#experience_gain_army = @chief_experience_gain_low
 
 		command_cap = @tier1
 		
@@ -6662,7 +6663,7 @@ leader_traits = {
 		sprite = 16
 		army_artillery_attack_factor = 0.15
 		army_artillery_defence_factor = 0.1
-		experience_gain_army = @experience_gain_medium
+		#experience_gain_army = @chief_experience_gain_medium
 
 		command_cap = @tier2
 		
@@ -6675,7 +6676,7 @@ leader_traits = {
 		sprite = 16
 		army_artillery_attack_factor = 0.2
 		army_artillery_defence_factor = 0.15
-		experience_gain_army = @experience_gain_high
+		#experience_gain_army = @chief_experience_gain_high
 
 		command_cap = @tier3
 		
@@ -6689,7 +6690,7 @@ leader_traits = {
 		sprite = 5
 		army_infantry_attack_factor = 0.05
 		army_infantry_defence_factor = 0.1
-		experience_gain_army = @experience_gain_low
+		#experience_gain_army = @chief_experience_gain_low
 
 		command_cap = @tier1
 		
@@ -6702,7 +6703,7 @@ leader_traits = {
 		sprite = 5
 		army_infantry_attack_factor = 0.1
 		army_infantry_defence_factor = 0.15
-		experience_gain_army = @experience_gain_medium
+		#experience_gain_army = @chief_experience_gain_medium
 
 		command_cap = @tier2
 		
@@ -6715,7 +6716,7 @@ leader_traits = {
 		sprite = 5
 		army_infantry_attack_factor = 0.15
 		army_infantry_defence_factor = 0.2
-		experience_gain_army = @experience_gain_high
+		#experience_gain_army = @chief_experience_gain_high
 
 		command_cap = @tier3
 		
@@ -6729,7 +6730,7 @@ leader_traits = {
 		sprite = 5
 		special_forces_attack_factor = 0.1
 	    special_forces_defence_factor = 0.1
-		experience_gain_army = @experience_gain_low
+		#experience_gain_army = @chief_experience_gain_low
 
 		command_cap = @tier1
 		
@@ -6742,7 +6743,7 @@ leader_traits = {
 		sprite = 5
 		special_forces_attack_factor = 0.15
 	    special_forces_defence_factor = 0.15
-		experience_gain_army = @experience_gain_medium
+		#experience_gain_army = @chief_experience_gain_medium
 
 		command_cap = @tier2
 		
@@ -6755,7 +6756,7 @@ leader_traits = {
 		sprite = 5
 		special_forces_attack_factor = 0.2
 	    special_forces_defence_factor = 0.2
-		experience_gain_army = @experience_gain_high
+		#experience_gain_army = @chief_experience_gain_high
 
 		command_cap = @tier3
 		
@@ -6769,7 +6770,7 @@ leader_traits = {
 		sprite = 17
 		cavalry_attack_factor = 0.05
 		cavalry_defence_factor = 0.05
-		experience_gain_army = @experience_gain_low
+		#experience_gain_army = @chief_experience_gain_low
 
 		command_cap = @tier1
 		
@@ -6782,7 +6783,7 @@ leader_traits = {
 		sprite = 17
 		cavalry_attack_factor = 0.1
 		cavalry_defence_factor = 0.1
-		experience_gain_army = @experience_gain_medium
+		#experience_gain_army = @chief_experience_gain_medium
 
 		command_cap = @tier2
 		
@@ -6795,7 +6796,7 @@ leader_traits = {
 		sprite = 17
 		cavalry_attack_factor = 0.15
 		cavalry_defence_factor = 0.15
-		experience_gain_army = @experience_gain_high
+		#experience_gain_army = @chief_experience_gain_high
 
 		command_cap = @tier3
 		
@@ -6809,7 +6810,7 @@ leader_traits = {
 		motorized_defence_factor = 0.05
 		mechanized_attack_factor = 0.05
 		mechanized_defence_factor = 0.05
-		experience_gain_army = @experience_gain_low
+		#experience_gain_army = @chief_experience_gain_low
 
 		command_cap = @tier1
 		
@@ -6824,7 +6825,7 @@ leader_traits = {
 		motorized_defence_factor = 0.1
 		mechanized_attack_factor = 0.1
 		mechanized_defence_factor = 0.1
-		experience_gain_army = @experience_gain_medium
+		#experience_gain_army = @chief_experience_gain_medium
 
 		command_cap = @tier2
 		
@@ -6839,7 +6840,7 @@ leader_traits = {
 		motorized_defence_factor = 0.15
 		mechanized_attack_factor = 0.15
 		mechanized_defence_factor = 0.15
-		experience_gain_army = @experience_gain_high
+		#experience_gain_army = @chief_experience_gain_high
 
 		command_cap = @tier3
 		
@@ -6851,7 +6852,7 @@ leader_traits = {
 	army_regrouping_1 = { # Org regenerates 4% faster
 		sprite = 5
 		army_morale_factor = 0.04
-		experience_gain_army = @experience_gain_low
+		#experience_gain_army = @chief_experience_gain_low
 
 		command_cap = @tier1
 		
@@ -6863,7 +6864,7 @@ leader_traits = {
 	army_regrouping_2 = { # Org regenerates 8% faster
 		sprite = 5
 		army_morale_factor = 0.08
-		experience_gain_army = @experience_gain_medium
+	#	experience_gain_army = @chief_experience_gain_medium
 
 		command_cap = @tier2
 		
@@ -6875,7 +6876,7 @@ leader_traits = {
 	army_regrouping_3 = { # Org regenerates 12% faster
 		sprite = 5
 		army_morale_factor = 0.12
-		experience_gain_army = @experience_gain_high
+	#	experience_gain_army = @chief_experience_gain_high
 
 		command_cap = @tier3
 		
@@ -6888,7 +6889,7 @@ leader_traits = {
 	army_concealment_1 = { # Ground units take less damage from air attacks
 		sprite = 9
 		enemy_army_bonus_air_superiority_factor = -0.05
-		experience_gain_army = @experience_gain_low
+	#	experience_gain_army = @chief_experience_gain_low
 
 		command_cap = @tier1
 		
@@ -6900,7 +6901,7 @@ leader_traits = {
 	army_concealment_2 = { # Ground units take less damage from air attacks
 		sprite = 9
 		enemy_army_bonus_air_superiority_factor = -0.10
-		experience_gain_army = @experience_gain_medium
+	#	experience_gain_army = @chief_experience_gain_medium
 
 		command_cap = @tier2
 		
@@ -6912,7 +6913,7 @@ leader_traits = {
 	army_concealment_3 = { # Ground units take less damage from air attacks
 		sprite = 9
 		enemy_army_bonus_air_superiority_factor = -0.15
-		experience_gain_army = @experience_gain_high
+	#	experience_gain_army = @chief_experience_gain_high
 
 		command_cap = @tier3
 		
@@ -6925,7 +6926,7 @@ leader_traits = {
 	army_logistics_1 = {  # Ground units suffer 4% less attrition
 		sprite = 6
 		attrition = -0.04
-		experience_gain_army = @experience_gain_low
+	#	experience_gain_army = @chief_experience_gain_low
 
 		command_cap = @tier1
 		
@@ -6937,7 +6938,7 @@ leader_traits = {
 	army_logistics_2 = {  # Ground units suffer 8% less attrition
 		sprite = 6
 		attrition = -0.08
-		experience_gain_army = @experience_gain_medium
+	#	experience_gain_army = @chief_experience_gain_medium
 
 		command_cap = @tier2
 		
@@ -6949,7 +6950,7 @@ leader_traits = {
 	army_logistics_3 = {  # Ground units suffer 12% less attrition
 		sprite = 6
 		attrition = -0.12
-		experience_gain_army = @experience_gain_high
+	#	experience_gain_army = @chief_experience_gain_high
 
 		command_cap = @tier3
 		
@@ -6961,8 +6962,8 @@ leader_traits = {
 
 	air_chief_reform_1 = {  # Rate at which air experience is gained increases by 5%
 		sprite = 19
-		experience_gain_air = @experience_gain_low
-		experience_gain_air_factor = 0.05
+		experience_gain_air = @chief_experience_gain_low
+		experience_gain_air_factor = 0.10
 
 		command_cap = @tier1
 		
@@ -6973,8 +6974,8 @@ leader_traits = {
 
 	air_chief_reform_2 = {  # Rate at which air experience is gained increases by 10%
 		sprite = 19
-		experience_gain_air = @experience_gain_medium
-		experience_gain_air_factor = 0.10
+		experience_gain_air = @chief_experience_gain_medium
+		experience_gain_air_factor = 0.20
 
 		command_cap = @tier2
 		
@@ -6985,7 +6986,7 @@ leader_traits = {
 
 	air_chief_reform_3 = {  # Rate at which air experience is gained increases by 15%
 		sprite = 19
-		experience_gain_air = @experience_gain_high
+		experience_gain_air = @chief_experience_gain_high
 		experience_gain_air_factor = 0.15
 
 		command_cap = @tier3
@@ -6998,8 +6999,8 @@ leader_traits = {
 
 	air_chief_safety_1 = {  # Rate of air accidents reduced by 5%
 		sprite = 1
-		air_accidents_factor = -0.05
-		experience_gain_air = @experience_gain_low
+		air_accidents_factor = -0.1
+		experience_gain_air = @chief_experience_gain_low
 
 		command_cap = @tier1
 		
@@ -7010,8 +7011,8 @@ leader_traits = {
 
 	air_chief_safety_2 = {  # Rate of air accidents reduced by 10%
 		sprite = 1
-		air_accidents_factor = -0.1
-		experience_gain_air = @experience_gain_medium
+		air_accidents_factor = -0.2
+		experience_gain_air = @chief_experience_gain_medium
 
 		command_cap = @tier2
 		
@@ -7022,8 +7023,8 @@ leader_traits = {
 
 	air_chief_safety_3 = {  # Rate of air accidents reduced by 15%
 		sprite = 1
-		air_accidents_factor = -0.15
-		experience_gain_air = @experience_gain_high
+		air_accidents_factor = -0.3
+		experience_gain_air = @chief_experience_gain_high
 
 		command_cap = @tier3
 		
@@ -7034,9 +7035,9 @@ leader_traits = {
 
 	air_chief_old_guard = {
 		sprite = 18
-		experience_gain_air = @experience_gain_medium
-		max_command_power = 20
-		political_power_factor = 0.075
+		experience_gain_air = @chief_experience_gain_medium
+		max_command_power = 40
+		political_power_factor = 0.1
 		
 		ai_will_do = {
 			factor = 1
@@ -7046,7 +7047,7 @@ leader_traits = {
 	air_chief_night_operations_1 = {
 		sprite = 1
 		air_night_penalty = -0.1
-		experience_gain_air = @experience_gain_low
+		experience_gain_air = @chief_experience_gain_low
 
 		command_cap = @tier1
 		
@@ -7058,7 +7059,7 @@ leader_traits = {
 	air_chief_night_operations_2 = {
 		sprite = 1
 		air_night_penalty = -0.2
-		experience_gain_air = @experience_gain_medium
+		experience_gain_air = @chief_experience_gain_medium
 
 		command_cap = @tier2
 		
@@ -7070,7 +7071,7 @@ leader_traits = {
 	air_chief_night_operations_3 = {
 		sprite = 1
 		air_night_penalty = -0.3
-		experience_gain_air = @experience_gain_high
+		experience_gain_air = @chief_experience_gain_high
 
 		command_cap = @tier3
 		
@@ -7082,8 +7083,8 @@ leader_traits = {
 
 	air_chief_ground_support_1 = {  # Air superiority impact on land units improved by 5%
 		sprite = 2
-		army_bonus_air_superiority_factor = 0.05
-		experience_gain_air = @experience_gain_low
+		army_bonus_air_superiority_factor = 0.1
+		experience_gain_air = @chief_experience_gain_low
 
 		command_cap = @tier1
 		
@@ -7094,8 +7095,8 @@ leader_traits = {
 
 	air_chief_ground_support_2 = {  # Air superiority impact on land units improved by 10%
 		sprite = 2
-		army_bonus_air_superiority_factor = 0.1
-		experience_gain_air = @experience_gain_medium
+		army_bonus_air_superiority_factor = 0.15
+		experience_gain_air = @chief_experience_gain_medium
 
 		command_cap = @tier2
 		
@@ -7106,8 +7107,8 @@ leader_traits = {
 
 	air_chief_ground_support_3 = {  # Air superiority impact on land units improved by 15%
 		sprite = 2
-		army_bonus_air_superiority_factor = 0.15
-		experience_gain_air = @experience_gain_high
+		army_bonus_air_superiority_factor = 0.2
+		experience_gain_air = @chief_experience_gain_high
 
 		command_cap = @tier3
 		
@@ -7120,8 +7121,8 @@ leader_traits = {
 	# using factor in stead of values because it is applied in ALL weathers (means bonus in good weather)
 	air_chief_all_weather_1 = {  # +5 bad weather air efficiency
 		sprite = 1
-		air_weather_penalty = -0.1
-		experience_gain_air = @experience_gain_low
+		air_weather_penalty = -0.2
+		experience_gain_air = @chief_experience_gain_low
 
 		command_cap = @tier1
 		
@@ -7132,8 +7133,8 @@ leader_traits = {
 
 	air_chief_all_weather_2 = {  # +10 bad weather air efficiency
 		sprite = 1
-		air_weather_penalty = -0.2
-		experience_gain_air = @experience_gain_medium
+		air_weather_penalty = -0.3
+		experience_gain_air = @chief_experience_gain_medium
 
 		command_cap = @tier2
 		
@@ -7144,8 +7145,8 @@ leader_traits = {
 
 	air_chief_all_weather_3 = {  # +15 bad weather air efficiency
 		sprite = 1
-		air_weather_penalty = -0.3
-		experience_gain_air = @experience_gain_high
+		air_weather_penalty = -0.4
+		experience_gain_air = @chief_experience_gain_high
 
 		command_cap = @tier3
 		
@@ -7157,8 +7158,8 @@ leader_traits = {
 
 	air_air_combat_training_1 = {  # Chance of ace generating is increased by 5%
 		sprite = 1
-		air_ace_generation_chance_factor = 0.05
-		experience_gain_air = @experience_gain_low
+		air_ace_generation_chance_factor = 0.1
+		#experience_gain_air = @chief_experience_gain_low
 
 		command_cap = @tier1
 		
@@ -7169,8 +7170,8 @@ leader_traits = {
 
 	air_air_combat_training_2 = {  # Chance of ace generating is increased by 10%
 		sprite = 1
-		air_ace_generation_chance_factor = 0.1
-		experience_gain_air = @experience_gain_medium
+		air_ace_generation_chance_factor = 0.15
+		#experience_gain_air = @chief_experience_gain_medium
 
 		command_cap = @tier2
 		
@@ -7181,8 +7182,8 @@ leader_traits = {
 
 	air_air_combat_training_3 = {  # Chance of ace generating is increased by 15%
 		sprite = 1
-		air_ace_generation_chance_factor = 0.15
-		experience_gain_air = @experience_gain_high
+		air_ace_generation_chance_factor = 0.2
+	#	experience_gain_air = @chief_experience_gain_high
 
 		command_cap = @tier3
 		
@@ -7197,7 +7198,7 @@ leader_traits = {
 		naval_strike_attack_factor = 0.02
 		naval_strike_targetting_factor = 0.02
 		naval_strike_agility_factor = 0.02
-		experience_gain_air = @experience_gain_low
+		#experience_gain_air = @chief_experience_gain_low
 
 		command_cap = @tier1
 		
@@ -7211,7 +7212,7 @@ leader_traits = {
 		naval_strike_attack_factor = 0.03
 		naval_strike_targetting_factor = 0.03
 		naval_strike_agility_factor = 0.03
-		experience_gain_air = @experience_gain_medium
+		#experience_gain_air = @chief_experience_gain_medium
 
 		command_cap = @tier2
 		
@@ -7225,7 +7226,7 @@ leader_traits = {
 		naval_strike_attack_factor = 0.05
 		naval_strike_targetting_factor = 0.05
 		naval_strike_agility_factor = 0.05
-		experience_gain_air = @experience_gain_high
+	#	experience_gain_air = @chief_experience_gain_high
 
 		command_cap = @tier3
 		
@@ -7240,7 +7241,7 @@ leader_traits = {
 		air_interception_attack_factor = 0.02
 		air_interception_defence_factor = 0.02
 		air_interception_agility_factor = 0.02
-		experience_gain_air = @experience_gain_low
+	#	experience_gain_air = @chief_experience_gain_low
 
 		command_cap = @tier1
 		
@@ -7254,7 +7255,7 @@ leader_traits = {
 		air_interception_attack_factor = 0.03
 		air_interception_defence_factor = 0.03
 		air_interception_agility_factor = 0.03
-		experience_gain_air = @experience_gain_medium
+	#	experience_gain_air = @chief_experience_gain_medium
 
 		command_cap = @tier2
 		
@@ -7268,7 +7269,7 @@ leader_traits = {
 		air_interception_attack_factor = 0.05
 		air_interception_defence_factor = 0.05
 		air_interception_agility_factor = 0.05
-		experience_gain_air = @experience_gain_high
+	#	experience_gain_air = @chief_experience_gain_high
 
 		command_cap = @tier3
 		
@@ -7283,7 +7284,7 @@ leader_traits = {
 		air_air_superiority_attack_factor = 0.02
 		air_air_superiority_defence_factor = 0.02
 		air_air_superiority_agility_factor = 0.02
-		experience_gain_air = @experience_gain_low
+	#	experience_gain_air = @chief_experience_gain_low
 
 		command_cap = @tier1
 		
@@ -7297,7 +7298,7 @@ leader_traits = {
 		air_air_superiority_attack_factor = 0.03
 		air_air_superiority_defence_factor = 0.03
 		air_air_superiority_agility_factor = 0.03
-		experience_gain_air = @experience_gain_medium
+	#	experience_gain_air = @chief_experience_gain_medium
 
 		command_cap = @tier2
 		
@@ -7311,7 +7312,7 @@ leader_traits = {
 		air_air_superiority_attack_factor = 0.05
 		air_air_superiority_defence_factor = 0.05
 		air_air_superiority_agility_factor = 0.05
-		experience_gain_air = @experience_gain_high
+	#	experience_gain_air = @chief_experience_gain_high
 
 		command_cap = @tier3
 		
@@ -7326,7 +7327,7 @@ leader_traits = {
 		air_close_air_support_attack_factor = 0.02
 		air_close_air_support_defence_factor = 0.02
 		air_close_air_support_agility_factor = 0.02
-		experience_gain_air = @experience_gain_low
+	#	experience_gain_air = @chief_experience_gain_low
 
 		command_cap = @tier1
 		
@@ -7340,7 +7341,7 @@ leader_traits = {
 		air_close_air_support_attack_factor = 0.03
 		air_close_air_support_defence_factor = 0.03
 		air_close_air_support_agility_factor = 0.03
-		experience_gain_air = @experience_gain_medium
+	#	experience_gain_air = @chief_experience_gain_medium
 
 		command_cap = @tier2
 		
@@ -7354,7 +7355,7 @@ leader_traits = {
 		air_close_air_support_attack_factor = 0.05
 		air_close_air_support_defence_factor = 0.05
 		air_close_air_support_agility_factor = 0.05
-		experience_gain_air = @experience_gain_high
+	#	experience_gain_air = @chief_experience_gain_high
 
 		command_cap = @tier3
 		
@@ -7366,11 +7367,11 @@ leader_traits = {
 
 	air_strategic_bombing_1 = { # Strategic Bombing mission efficiency increased by 4%
 		sprite = 2
-		air_strategic_bomber_attack_factor = 0.01
-		air_strategic_bomber_defence_factor = 0.01
-		air_strategic_bomber_agility_factor = 0.01
+		air_strategic_bomber_attack_factor = 0.02
+		air_strategic_bomber_defence_factor = 0.02
+		air_strategic_bomber_agility_factor = 0.02
 		air_strategic_bomber_bombing_factor = 0.03
-		experience_gain_air = @experience_gain_low
+	#	experience_gain_air = @chief_experience_gain_low
 
 		command_cap = @tier1
 		
@@ -7381,11 +7382,11 @@ leader_traits = {
 
 	air_strategic_bombing_2 = { # Strategic Bombing mission efficiency increased by 8%
 		sprite = 2
-		air_strategic_bomber_attack_factor = 0.02
-		air_strategic_bomber_defence_factor = 0.02
-		air_strategic_bomber_agility_factor = 0.02
+		air_strategic_bomber_attack_factor = 0.03
+		air_strategic_bomber_defence_factor = 0.03
+		air_strategic_bomber_agility_factor = 0.03
 		air_strategic_bomber_bombing_factor = 0.05
-		experience_gain_air = @experience_gain_medium
+		#experience_gain_air = @chief_experience_gain_medium
 
 		command_cap = @tier2
 		
@@ -7396,11 +7397,11 @@ leader_traits = {
 
 	air_strategic_bombing_3 = { # Strategic Bombing mission efficiency increased by 12%
 		sprite = 2
-		air_strategic_bomber_attack_factor = 0.03
-		air_strategic_bomber_defence_factor = 0.03
-		air_strategic_bomber_agility_factor = 0.03
+		air_strategic_bomber_attack_factor = 0.04
+		air_strategic_bomber_defence_factor = 0.04
+		air_strategic_bomber_agility_factor = 0.04
 		air_strategic_bomber_bombing_factor = 0.09
-		experience_gain_air = @experience_gain_high
+	#	experience_gain_air = @chief_experience_gain_high
 
 		command_cap = @tier3
 		
@@ -7413,7 +7414,7 @@ leader_traits = {
 	air_tactical_bombing_1 = { # Tactical Bombing mission efficiency increased
 		sprite = 2
 		air_cas_present_factor = 0.1
-		experience_gain_air = @experience_gain_low
+		#experience_gain_air = @chief_experience_gain_low
 
 		command_cap = @tier1
 		
@@ -7425,7 +7426,7 @@ leader_traits = {
 	air_tactical_bombing_2 = { # Tactical Bombing mission efficiency increased
 		sprite = 2
 		air_cas_present_factor = 0.15
-		experience_gain_air = @experience_gain_medium
+		#experience_gain_air = @chief_experience_gain_medium
 
 		command_cap = @tier2
 		
@@ -7437,7 +7438,7 @@ leader_traits = {
 	air_tactical_bombing_3 = { # Tactical Bombing mission efficiency increased
 		sprite = 2
 		air_cas_present_factor = 0.2
-		experience_gain_air = @experience_gain_high
+	#	experience_gain_air = @chief_experience_gain_high
 
 		command_cap = @tier3
 		
@@ -7452,7 +7453,7 @@ leader_traits = {
 		air_paradrop_attack_factor = 0.01
 		air_paradrop_defence_factor = 0.03
 		air_paradrop_agility_factor = 0.03
-		experience_gain_air = @experience_gain_low
+	#	experience_gain_air = @chief_experience_gain_low
 
 		command_cap = @tier1
 		
@@ -7466,7 +7467,7 @@ leader_traits = {
 		air_paradrop_attack_factor = 0.02
 		air_paradrop_defence_factor = 0.05
 		air_paradrop_agility_factor = 0.05
-		experience_gain_air = @experience_gain_medium
+	#	experience_gain_air = @chief_experience_gain_medium
 
 		command_cap = @tier2
 		
@@ -7480,7 +7481,7 @@ leader_traits = {
 		air_paradrop_attack_factor = 0.03
 		air_paradrop_defence_factor = 0.07
 		air_paradrop_agility_factor = 0.07
-		experience_gain_air = @experience_gain_high
+	#	experience_gain_air = @chief_experience_gain_high
 
 		command_cap = @tier3
 		
@@ -7491,8 +7492,8 @@ leader_traits = {
 
 	air_pilot_training_1 = {
 		sprite = 1
-		air_training_xp_gain_factor = 0.05
-		experience_gain_air = @experience_gain_low
+		air_training_xp_gain_factor = 0.1
+	#	experience_gain_air = @chief_experience_gain_low
 
 		command_cap = @tier1
 		
@@ -7502,8 +7503,8 @@ leader_traits = {
 	}
 	air_pilot_training_2 = {
 		sprite = 1
-		air_training_xp_gain_factor = 0.1
-		experience_gain_air = @experience_gain_medium
+		air_training_xp_gain_factor = 0.15
+	#	experience_gain_air = @chief_experience_gain_medium
 
 		command_cap = @tier2
 		
@@ -7513,8 +7514,8 @@ leader_traits = {
 	}
 	air_pilot_training_3 = {
 		sprite = 1
-		air_training_xp_gain_factor = 0.15
-		experience_gain_air = @experience_gain_high
+		air_training_xp_gain_factor = 0.2
+	#	experience_gain_air = @chief_experience_gain_high
 
 		command_cap = @tier3
 		
@@ -7526,10 +7527,10 @@ leader_traits = {
 
 	navy_chief_naval_aviation_1 = {
 		sprite = 1
-		navy_carrier_air_attack_factor = 0.03
-		navy_carrier_air_targetting_factor = 0.03
-		navy_carrier_air_agility_factor = 0.04
-		experience_gain_navy = @experience_gain_low
+		navy_carrier_air_attack_factor = 0.04
+		navy_carrier_air_targetting_factor = 0.04
+		navy_carrier_air_agility_factor = 0.05
+		experience_gain_navy = @chief_experience_gain_low
 
 		command_cap = @tier1
 		
@@ -7540,10 +7541,10 @@ leader_traits = {
 
 	navy_chief_naval_aviation_2 = {
 		sprite = 1
-		navy_carrier_air_attack_factor = 0.06
-		navy_carrier_air_targetting_factor = 0.07
-		navy_carrier_air_agility_factor = 0.08
-		experience_gain_navy = @experience_gain_medium
+		navy_carrier_air_attack_factor = 0.07
+		navy_carrier_air_targetting_factor = 0.08
+		navy_carrier_air_agility_factor = 0.09
+		experience_gain_navy = @chief_experience_gain_medium
 
 		command_cap = @tier2
 		
@@ -7554,10 +7555,10 @@ leader_traits = {
 
 	navy_chief_naval_aviation_3 = {
 		sprite = 1
-		navy_carrier_air_attack_factor = 0.1
-		navy_carrier_air_targetting_factor = 0.12
+		navy_carrier_air_attack_factor = 0.11
+		navy_carrier_air_targetting_factor = 0.13
 		navy_carrier_air_agility_factor = 0.15
-		experience_gain_navy = @experience_gain_high
+		experience_gain_navy = @chief_experience_gain_high
 
 		command_cap = @tier3
 		
@@ -7573,7 +7574,7 @@ leader_traits = {
 		navy_capital_ship_defence_factor = 0.05
 		navy_screen_attack_factor = 0.05
 		navy_screen_defence_factor = 0.05
-		experience_gain_navy = @experience_gain_low
+		experience_gain_navy = @chief_experience_gain_low
 
 		command_cap = @tier1
 		
@@ -7588,7 +7589,7 @@ leader_traits = {
 		navy_capital_ship_defence_factor = 0.1
 		navy_screen_attack_factor = 0.1
 		navy_screen_defence_factor = 0.1
-		experience_gain_navy = @experience_gain_medium
+		experience_gain_navy = @chief_experience_gain_medium
 
 		command_cap = @tier2
 		
@@ -7603,7 +7604,7 @@ leader_traits = {
 		navy_capital_ship_defence_factor = 0.15
 		navy_screen_attack_factor = 0.15
 		navy_screen_defence_factor = 0.15
-		experience_gain_navy = @experience_gain_high
+		experience_gain_navy = @chief_experience_gain_high
 
 		command_cap = @tier3
 		
@@ -7616,7 +7617,7 @@ leader_traits = {
 	navy_chief_commerce_raiding_1 = {
 		sprite = 3
 		convoy_raiding_efficiency_factor = 0.1
-		experience_gain_navy = @experience_gain_low
+		experience_gain_navy = @chief_experience_gain_low
 
 		command_cap = @tier1
 		
@@ -7628,7 +7629,7 @@ leader_traits = {
 	navy_chief_commerce_raiding_2 = {
 		sprite = 3
 		convoy_raiding_efficiency_factor = 0.15
-		experience_gain_navy = @experience_gain_medium
+		experience_gain_navy = @chief_experience_gain_medium
 
 		command_cap = @tier2
 		
@@ -7640,7 +7641,7 @@ leader_traits = {
 	navy_chief_commerce_raiding_3 = {
 		sprite = 3
 		convoy_raiding_efficiency_factor = 0.2
-		experience_gain_navy = @experience_gain_high
+		experience_gain_navy = @chief_experience_gain_high
 
 		command_cap = @tier3
 		
@@ -7651,10 +7652,10 @@ leader_traits = {
 
 	navy_chief_old_guard = {
 		sprite = 18
-		experience_gain_navy = @experience_gain_high_old_guard
+		experience_gain_navy = @chief_experience_gain_high_old_guard
 
-		max_command_power = 20
-		political_power_factor = 0.075
+		max_command_power = 40
+		political_power_factor = 0.1
 
 
 		ai_will_do = {
@@ -7664,8 +7665,8 @@ leader_traits = {
 
 	navy_chief_reform_1 = {
 		sprite = 19
-		experience_gain_navy = @experience_gain_low
-		experience_gain_navy_factor = 0.05
+		experience_gain_navy = @chief_experience_gain_low
+		experience_gain_navy_factor = 0.1
 
 		command_cap = @tier1
 		
@@ -7676,8 +7677,8 @@ leader_traits = {
 
 	navy_chief_reform_2 = {
 		sprite = 19
-		experience_gain_navy = @experience_gain_medium
-		experience_gain_navy_factor = 0.1
+		experience_gain_navy = @chief_experience_gain_medium
+		experience_gain_navy_factor = 0.2
 
 		command_cap = @tier2
 		
@@ -7688,8 +7689,8 @@ leader_traits = {
 
 	navy_chief_reform_3 = {
 		sprite = 19
-		experience_gain_navy = @experience_gain_high
-		experience_gain_navy_factor = 0.15
+		experience_gain_navy = @chief_experience_gain_high
+		experience_gain_navy_factor = 0.3
 
 		command_cap = @tier3
 		
@@ -7701,7 +7702,7 @@ leader_traits = {
 	navy_chief_maneuver_1 = { # Naval units move 5% faster
 		sprite = 3
 		naval_speed_factor = 0.05
-		experience_gain_navy = @experience_gain_low
+		experience_gain_navy = @chief_experience_gain_low
 
 		command_cap = @tier1
 		
@@ -7713,7 +7714,7 @@ leader_traits = {
 	navy_chief_maneuver_2 = { # Naval units move 10% faster
 		sprite = 3
 		naval_speed_factor = 0.1
-		experience_gain_navy = @experience_gain_medium
+		experience_gain_navy = @chief_experience_gain_medium
 
 		command_cap = @tier2
 		
@@ -7725,7 +7726,7 @@ leader_traits = {
 	navy_chief_maneuver_3 = { # Naval units move 15% faster
 		sprite = 3
 		naval_speed_factor = 0.15
-		experience_gain_navy = @experience_gain_high
+		experience_gain_navy = @chief_experience_gain_high
 
 		command_cap = @tier3
 		
@@ -7737,8 +7738,8 @@ leader_traits = {
 
 	navy_anti_submarine_1 = {
 		sprite = 4
-		navy_submarine_detection_factor = 0.1
-		experience_gain_navy = @experience_gain_low
+		navy_submarine_detection_factor = 0.15
+		#experience_gain_navy = @chief_experience_gain_low
 
 		command_cap = @tier1
 		
@@ -7749,8 +7750,8 @@ leader_traits = {
 
 	navy_anti_submarine_2 = {
 		sprite = 4
-		navy_submarine_detection_factor = 0.15
-		experience_gain_navy = @experience_gain_medium
+		navy_submarine_detection_factor = 0.2
+	#	experience_gain_navy = @chief_experience_gain_medium
 
 		command_cap = @tier2
 		
@@ -7761,8 +7762,8 @@ leader_traits = {
 	
 	navy_anti_submarine_3 = {
 		sprite = 4
-		navy_submarine_detection_factor = 0.2
-		experience_gain_navy = @experience_gain_high
+		navy_submarine_detection_factor = 0.25
+	#	experience_gain_navy = @chief_experience_gain_high
 
 		command_cap = @tier3
 		
@@ -7774,8 +7775,8 @@ leader_traits = {
 	
 	navy_naval_air_defense_1 = {
 		sprite = 3
-		navy_anti_air_attack_factor = 0.08
-		experience_gain_navy = @experience_gain_low
+		navy_anti_air_attack_factor = 0.1
+	#	experience_gain_navy = @chief_experience_gain_low
 
 		command_cap = @tier1
 		
@@ -7787,7 +7788,7 @@ leader_traits = {
 	navy_naval_air_defense_2 = {
 		sprite = 3
 		navy_anti_air_attack_factor = 0.15
-		experience_gain_navy = @experience_gain_medium
+	#	experience_gain_navy = @chief_experience_gain_medium
 
 		command_cap = @tier2
 		
@@ -7799,7 +7800,7 @@ leader_traits = {
 	navy_naval_air_defense_3 = {
 		sprite = 3
 		navy_anti_air_attack_factor = 0.2
-		experience_gain_navy = @experience_gain_high
+	#	experience_gain_navy = @chief_experience_gain_high
 
 		command_cap = @tier3
 		
@@ -7812,7 +7813,7 @@ leader_traits = {
 	navy_fleet_logistics_1 = {
 		sprite = 6
 		navy_max_range_factor = 0.05
-		experience_gain_navy = @experience_gain_low
+	#	experience_gain_navy = @chief_experience_gain_low
 
 		command_cap = @tier1
 		
@@ -7824,7 +7825,7 @@ leader_traits = {
 	navy_fleet_logistics_2 = {
 		sprite = 6
 		navy_max_range_factor = 0.10
-		experience_gain_navy = @experience_gain_medium
+	#	experience_gain_navy = @chief_experience_gain_medium
 
 		command_cap = @tier2
 		
@@ -7836,7 +7837,7 @@ leader_traits = {
 	navy_fleet_logistics_3 = {
 		sprite = 6
 		navy_max_range_factor = 0.15
-		experience_gain_navy = @experience_gain_high
+	#	experience_gain_navy = @chief_experience_gain_high
 
 		command_cap = @tier3
 		
@@ -7849,7 +7850,7 @@ leader_traits = {
 	navy_amphibious_assault_1 = {
 		sprite = 3
 		amphibious_invasion = 0.05
-		experience_gain_navy = @experience_gain_low
+		#experience_gain_navy = @chief_experience_gain_low
 
 		command_cap = @tier1
 		
@@ -7861,7 +7862,7 @@ leader_traits = {
 	navy_amphibious_assault_2 = {
 		sprite = 3
 		amphibious_invasion = 0.1
-		experience_gain_navy = @experience_gain_medium
+	#	experience_gain_navy = @chief_experience_gain_medium
 
 		command_cap = @tier2
 		
@@ -7873,7 +7874,7 @@ leader_traits = {
 	navy_amphibious_assault_3 = {
 		sprite = 3
 		amphibious_invasion = 0.15
-		experience_gain_navy = @experience_gain_high
+	#	experience_gain_navy = @chief_experience_gain_high
 
 		command_cap = @tier3
 		
@@ -7886,8 +7887,8 @@ leader_traits = {
 	navy_submarine_1 = {
 		sprite = 4
 		navy_submarine_attack_factor = 0.1
-		navy_submarine_defence_factor = 0.05
-		experience_gain_navy = @experience_gain_low
+		navy_submarine_defence_factor = 0.1
+	#	experience_gain_navy = @chief_experience_gain_low
 
 		command_cap = @tier1
 		
@@ -7899,8 +7900,8 @@ leader_traits = {
 	navy_submarine_2 = {
 		sprite = 4
 		navy_submarine_attack_factor = 0.15
-		navy_submarine_defence_factor = 0.1
-		experience_gain_navy = @experience_gain_medium
+		navy_submarine_defence_factor = 0.15
+	#	experience_gain_navy = @chief_experience_gain_medium
 
 		command_cap = @tier2
 		
@@ -7912,8 +7913,8 @@ leader_traits = {
 	navy_submarine_3 = {
 		sprite = 4
 		navy_submarine_attack_factor = 0.2
-		navy_submarine_defence_factor = 0.15
-		experience_gain_navy = @experience_gain_high
+		navy_submarine_defence_factor = 0.2
+	#	experience_gain_navy = @chief_experience_gain_high
 
 		command_cap = @tier3
 		
@@ -7927,7 +7928,7 @@ leader_traits = {
 		sprite = 3
 		navy_capital_ship_attack_factor = 0.05
 		navy_capital_ship_defence_factor = 0.05
-		experience_gain_navy = @experience_gain_low
+	#	experience_gain_navy = @chief_experience_gain_low
 
 		command_cap = @tier1
 		
@@ -7940,8 +7941,8 @@ leader_traits = {
 		sprite = 3
 		navy_capital_ship_attack_factor = 0.1
 		navy_capital_ship_defence_factor = 0.1
-		experience_gain_navy = @experience_gain_medium
-
+	#	experience_gain_navy = @chief_experience_gain_medium
+#
 		command_cap = @tier2
 		
 		ai_will_do = {
@@ -7953,7 +7954,7 @@ leader_traits = {
 		sprite = 3
 		navy_capital_ship_attack_factor = 0.15
 		navy_capital_ship_defence_factor = 0.15
-		experience_gain_navy = @experience_gain_high
+	#	experience_gain_navy = @chief_experience_gain_high
 
 		command_cap = @tier3
 		
@@ -7965,9 +7966,9 @@ leader_traits = {
 
 	navy_screen_1 = {
 		sprite = 3
-		navy_screen_attack_factor = 0.05
+		navy_screen_attack_factor = 0.1
 		navy_screen_defence_factor = 0.1
-		experience_gain_navy = @experience_gain_low
+	#$	experience_gain_navy = @chief_experience_gain_low
 
 		command_cap = @tier1
 		
@@ -7978,9 +7979,9 @@ leader_traits = {
 
 	navy_screen_2 = {
 		sprite = 3
-		navy_screen_attack_factor = 0.1
+		navy_screen_attack_factor = 0.15
 		navy_screen_defence_factor = 0.15
-		experience_gain_navy = @experience_gain_medium
+	#	experience_gain_navy = @chief_experience_gain_medium
 
 		command_cap = @tier2
 		
@@ -7991,9 +7992,9 @@ leader_traits = {
 
 	navy_screen_3 = {
 		sprite = 3
-		navy_screen_attack_factor = 0.15
+		navy_screen_attack_factor = 0.2
 		navy_screen_defence_factor = 0.2
-		experience_gain_navy = @experience_gain_high
+	#	experience_gain_navy = @chief_experience_gain_high
 
 		command_cap = @tier3
 		
@@ -8005,7 +8006,7 @@ leader_traits = {
 	navy_carrier_1 = {
 		sprite = 3
 		sortie_efficiency = 0.1
-		experience_gain_navy = @experience_gain_low
+	#	experience_gain_navy = @chief_experience_gain_low
 
 		command_cap = @tier1
 		
@@ -8016,8 +8017,8 @@ leader_traits = {
 
 	navy_carrier_2 = {
 		sprite = 3
-		sortie_efficiency = 0.15
-		experience_gain_navy = @experience_gain_medium
+		sortie_efficiency = 0.2
+	#	experience_gain_navy = @chief_experience_gain_medium
 
 		command_cap = @tier2
 		
@@ -8028,8 +8029,8 @@ leader_traits = {
 
 	navy_carrier_3 = {
 		sprite = 3
-		sortie_efficiency = 0.2
-		experience_gain_navy = @experience_gain_high
+		sortie_efficiency = 0.3
+	#	experience_gain_navy = @chief_experience_gain_high
 
 		command_cap = @tier3
 		
@@ -8047,7 +8048,72 @@ leader_traits = {
 		dig_in_speed_factor = 0.15
 		max_dig_in = 5
 		mobilization_speed = -0.05
-		experience_gain_army = @experience_gain_medium
+	#	experience_gain_army = @chief_experience_gain_medium
+		ai_will_do = {
+			factor = 1
+		}
+	}
+
+	evans_deakin_trait = { #at end for save compat
+	random = no
+	equipment_bonus = {
+		carrier = {
+			naval_range = 0.25
+		}
+		capital_ship = {
+			naval_range = 0.25
+		}
+		screen_ship = {
+			naval_range = 0.25
+		}
+		submarine = {
+			naval_range = 0.25
+			build_cost_ic = -0.1
+		}
+		convoy = {
+			build_cost_ic = -0.15
+		}
+	}
+
+	ai_will_do = {
+		factor = 1
+	}
+}
+	cockatoo_trait = { #at end for save compat
+		random = no
+		equipment_bonus = {
+			ship_hull_cruiser = { #CLs & CAs
+				naval_range = 0.4
+				sub_detection = 0.2 
+				naval_speed = 0.1
+			}
+			ship_hull_light = { #DDs
+				naval_range = 0.4 
+				sub_detection = 0.2
+				naval_speed = 0.1
+			}
+		}
+
+		ai_will_do = {
+			factor = 1
+		}
+	}
+	
+	cautious_arbiter = {
+		random = no
+		political_power_factor = 0.10
+		war_support_factor = -0.05
+		communism_acceptance = 30
+		
+		ai_will_do = {
+			factor = 1
+		}
+	}
+	
+	viceroy_emeritus = {
+		random = no
+		generate_wargoal_tension = 0.1
+		
 		ai_will_do = {
 			factor = 1
 		}

--- a/common/ideas/australia.txt
+++ b/common/ideas/australia.txt
@@ -568,13 +568,16 @@ ideas = {
 
 			allowed = {
 				original_TAG = AST
+				has_dlc = "Together for Victory"
 			}
-						
+			available = {
+				has_completed_focus = AST_R56_rebuild_cockatoo_island
+			}			
 			research_bonus = {
-				naval_equipment = 0.15
+				naval_equipment = 0.2
 			}
 			
-			traits = { convoy_escort_naval_manufacturer }
+			traits = { cockatoo_trait }
 
 		}
 		
@@ -584,15 +587,18 @@ ideas = {
 
 			allowed = {
 				original_TAG = AST
+				has_dlc = "Together for Victory"
 			}
 			
-
+			available = {
+				has_completed_focus = AST_R56_royal_australian_navy
+			}
 			
 			research_bonus = {
 				naval_equipment = 0.15
 			}
 			
-			traits = { pacific_fleet_naval_manufacturer }
+			traits = { evans_deakin_trait }
 		}
 		
 		

--- a/common/ideas/germany.txt
+++ b/common/ideas/germany.txt
@@ -2210,6 +2210,9 @@ ideas = {
 	naval_manufacturer = {
 		designer = yes
 		germaniawerft = {
+			available = {
+				has_completed_focus = GER_u_boat_effort_r56
+			}
 			allowed = {
 				OR = {
 					original_tag = WGR
@@ -2222,7 +2225,7 @@ ideas = {
 			equipment_bonus = {
 			}
 			traits = {
-				atlantic_fleet_naval_manufacturer
+				submarine_manufacturer
 			}
 		}
 		blohm_und_voss = {
@@ -2247,7 +2250,7 @@ ideas = {
 				original_tag = GER
 			}
 			research_bonus = {
-				naval_equipment = 0.1
+				naval_equipment = 0.15
 			}
 			traits = {
 				battlefleet_designer

--- a/common/ideas/italy.txt
+++ b/common/ideas/italy.txt
@@ -3578,7 +3578,7 @@ ideas = {
 				}
 				submarine = {
 					instant = yes 
-					build_cost_ic = 0.3
+					build_cost_ic = 3
 				}
 			}
 		}

--- a/common/ideas/navy_spirits.txt
+++ b/common/ideas/navy_spirits.txt
@@ -364,9 +364,9 @@ ideas = {
 				}
 			}
 			modifier = {
-				refit_ic_cost = -0.25
+				#refit_ic_cost = -0.25
 				refit_speed = 0.25
-				repair_speed_factor = 0.25
+				repair_speed_factor = 0.35
 			}
 			ai_will_do = {
 				factor = 1

--- a/common/ideas/peace_training.txt
+++ b/common/ideas/peace_training.txt
@@ -15,9 +15,9 @@ ideas = {
                 air_accidents_factor = -2
                 naval_accidents_chance = -2
 
-				experience_gain_army = 0.4
-				experience_gain_navy = 0.4
-				experience_gain_air = 0.4
+				#experience_gain_army = 0.4
+				#experience_gain_navy = 0.4
+				#experience_gain_air = 0.4
 			}
 		}
 	}

--- a/common/national_focus/germany.txt
+++ b/common/national_focus/germany.txt
@@ -2613,6 +2613,32 @@ focus_tree = {
 			}
 		}
 		completion_reward = {
+			989 = {
+				add_extra_state_shared_building_slots = 2
+				add_building_construction = {
+					type = industrial_complex
+					level = 2
+					instant_build = yes
+				}
+				add_building_construction = {
+					type = infrastructure
+					level = 1
+					instant_build = yes
+				}
+			}
+			922 = {
+				add_extra_state_shared_building_slots = 2
+				add_building_construction = {
+					type = industrial_complex
+					level = 2
+					instant_build = yes
+				}
+				add_building_construction = {
+					type = infrastructure
+					level = 1
+					instant_build = yes
+				}
+			}
 			51 = {
 				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
@@ -2622,33 +2648,7 @@ focus_tree = {
 				}
 				add_building_construction = {
 					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
-			}
-			63 = {
-				add_extra_state_shared_building_slots = 2
-				add_building_construction = {
-					type = industrial_complex
-					level = 2
-					instant_build = yes
-				}
-				add_building_construction = {
-					type = infrastructure
-					level = 2
-					instant_build = yes
-				}
-			}
-			5 = {
-				add_extra_state_shared_building_slots = 2
-				add_building_construction = {
-					type = industrial_complex
-					level = 2
-					instant_build = yes
-				}
-				add_building_construction = {
-					type = infrastructure
-					level = 2
+					level = 1
 					instant_build = yes
 				}
 			}
@@ -2679,7 +2679,7 @@ focus_tree = {
 			}
 		}
 		completion_reward = {
-			64 = {
+			989 = {
 				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = industrial_complex
@@ -2687,7 +2687,7 @@ focus_tree = {
 					instant_build = yes
 				}
 			}
-			59 = {
+			922 = {
 				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = industrial_complex
@@ -2695,7 +2695,7 @@ focus_tree = {
 					instant_build = yes
 				}
 			}
-			60 = {
+			51 = {
 				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = industrial_complex
@@ -3015,27 +3015,39 @@ focus_tree = {
 			}
 		}
 		completion_reward = {
+			build_railway = { #
+				level = 5
+				path = {
+					6521 3499 9456 3522 6487 425 3561 9524 6549 3524 6488 11560 11547 11531
+				}
+			}
+			build_railway = { #
+				level = 5
+				path = {
+					6521 3499 9456 3522 6487 425 3561 9524 6549 3524 6488 589 6568 9517 3530 6542 6712 3692
+				}
+			}
 			42 = {
 				add_building_construction = {
 					type = infrastructure
-					level = 2
+					level = 1
 					instant_build = yes
 				}
 				add_building_construction = {
 					type = air_base
-					level = 4
+					level = 5
 					instant_build = yes
 				}
 			}
-			51 = {
+			923 = {
 				add_building_construction = {
 					type = infrastructure
-					level = 2
+					level = 1
 					instant_build = yes
 				}
 				add_building_construction = {
 					type = air_base
-					level = 4
+					level = 5
 					instant_build = yes
 				}
 			}
@@ -4298,25 +4310,25 @@ focus_tree = {
 							is_core_of = SWI
 							
 							#Wrong side of the Rhine
-							state = 51
+							#state = 51
 							state = 42
 							state = 28
-							state = 67
+							#state = 67
 
 							#Wrong side of the Oder
 							state = 5
-							state = 763
+							#state = 763
 							state = 85
 							state = 965
-							state = 63
-							state = 68
-							state = 66
+							#state = 63
+							#state = 68
+							#state = 66
 
 							#too south
-							state = 923
-							state = 50
-							state = 52
-							state = 53
+							#state = 923
+							#state = 50
+							#state = 52
+							#state = 53
 
 							#too north
 							state = 998
@@ -4326,7 +4338,7 @@ focus_tree = {
 				hidden_effect = {
 					add_building_construction = {
 						type = bunker
-						level = 5
+						level = 7
 						instant_build = yes
 						province = {
 							limit_to_victory_point = yes
@@ -4367,11 +4379,17 @@ focus_tree = {
 				limit = {
 					ROOT = {
 						OR = {
-							controls_province = 9496
-							controls_province = 3207
 							controls_province = 6282
-							controls_province = 3572 
+							controls_province = 3207
+							controls_province = 9496
+							controls_province = 3572
 							controls_province = 3438
+							controls_province = 6595 
+							controls_province = 552
+							controls_province = 3545
+							controls_province = 9570
+							controls_province = 6512
+							controls_province = 9457
 						}
 					}
 				}
@@ -4379,10 +4397,12 @@ focus_tree = {
 					limit = {
 						is_core_of = GER
 						OR = {
-							state = 64
+							state = 62
 							state = 63
-							state = 68
+							state = 64
 							state = 66
+							state = 67
+							state = 68
 						}
 					}
 					custom_effect_tooltip = GER_a_world_in_flames_2_tt
@@ -4392,11 +4412,18 @@ focus_tree = {
 				limit = {
 					ROOT = {
 						OR = {
+							controls_province = 3512
 							controls_province = 6469
 							controls_province = 6570
 							controls_province = 529
 							controls_province = 6444
 							controls_province = 6488
+							controls_province = 589
+							controls_province = 6568
+							controls_province = 3530
+							controls_province = 6542
+							controls_province = 6712
+							controls_province = 11640
 						}
 					}
 				}
@@ -4406,6 +4433,7 @@ focus_tree = {
 						OR = {
 							state = 922
 							state = 989
+							state = 923
 						}
 					}
 					custom_effect_tooltip = GER_a_world_in_flames_3_tt
@@ -4415,13 +4443,13 @@ focus_tree = {
 				#Oder Forts
 				if = {
 					limit = {
-						ROOT = { controls_province = 9496 }
+						ROOT = { controls_province = 6282 }
 					}
-					64 = {
+					63 = {
 						add_building_construction = {
 							type = bunker
-							level = 1
-							province = 9496
+							level = 5
+							province = 6282
 							instant_build = yes
 						}
 					}
@@ -4433,7 +4461,7 @@ focus_tree = {
 					62 = {
 						add_building_construction = {
 							type = bunker
-							level = 1
+							level = 5
 							province = 3207
 							instant_build = yes
 						}
@@ -4441,13 +4469,13 @@ focus_tree = {
 				}
 				if = {
 					limit = {
-						ROOT = { controls_province = 6282 }
+						ROOT = { controls_province = 9496 }
 					}
-					63 = {
+					64 = {
 						add_building_construction = {
 							type = bunker
-							level = 1
-							province = 6282
+							level = 5
+							province = 9496
 							instant_build = yes
 						}
 					}
@@ -4459,7 +4487,7 @@ focus_tree = {
 					68 = {
 						add_building_construction = {
 							type = bunker
-							level = 1
+							level = 5
 							province = 3572
 							instant_build = yes
 						}
@@ -4472,8 +4500,86 @@ focus_tree = {
 					66 = {
 						add_building_construction = {
 							type = bunker
-							level = 1
+							level = 5
 							province = 3438
+							instant_build = yes
+						}
+					}
+				}
+				if = {
+					limit = {
+						ROOT = { controls_province = 6595 }
+					}
+					66 = {
+						add_building_construction = {
+							type = bunker
+							level = 5
+							province = 6595
+							instant_build = yes
+						}
+					}
+				}
+				if = {
+					limit = {
+						ROOT = { controls_province = 552 }
+					}
+					66 = {
+						add_building_construction = {
+							type = bunker
+							level = 5
+							province = 552
+							instant_build = yes
+						}
+					}
+				}
+				if = {
+					limit = {
+						ROOT = { controls_province = 3545 }
+					}
+					66 = {
+						add_building_construction = {
+							type = bunker
+							level = 5
+							province = 3545
+							instant_build = yes
+						}
+					}
+				}
+				if = {
+					limit = {
+						ROOT = { controls_province = 9570 }
+					}
+					66 = {
+						add_building_construction = {
+							type = bunker
+							level = 5
+							province = 9570
+							instant_build = yes
+						}
+					}
+				}
+				if = {
+					limit = {
+						ROOT = { controls_province = 6512 }
+					}
+					67 = {
+						add_building_construction = {
+							type = bunker
+							level = 5
+							province = 6512
+							instant_build = yes
+						}
+					}
+				}
+				if = {
+					limit = {
+						ROOT = { controls_province = 9457 }
+					}
+					67 = {
+						add_building_construction = {
+							type = bunker
+							level = 5
+							province = 9457
 							instant_build = yes
 						}
 					}
@@ -4481,12 +4587,25 @@ focus_tree = {
 				#Rhine Forts
 				if = {
 					limit = {
+						ROOT = { controls_province = 3512 }
+					}
+					989 = {
+						add_building_construction = {
+							type = bunker
+							level = 5
+							province = 3512
+							instant_build = yes
+						}
+					}
+				}
+				if = {
+					limit = {
 						ROOT = { controls_province = 6469 }
 					}
 					989 = {
 						add_building_construction = {
 							type = bunker
-							level = 1
+							level = 5
 							province = 6469
 							instant_build = yes
 						}
@@ -4499,7 +4618,7 @@ focus_tree = {
 					989 = {
 						add_building_construction = {
 							type = bunker
-							level = 1
+							level = 5
 							province = 6570
 							instant_build = yes
 						}
@@ -4512,7 +4631,7 @@ focus_tree = {
 					989 = {
 						add_building_construction = {
 							type = bunker
-							level = 1
+							level = 5
 							province = 529
 							instant_build = yes
 						}
@@ -4525,7 +4644,7 @@ focus_tree = {
 					922 = {
 						add_building_construction = {
 							type = bunker
-							level = 1
+							level = 5
 							province = 6444
 							instant_build = yes
 						}
@@ -4538,8 +4657,86 @@ focus_tree = {
 					922 = {
 						add_building_construction = {
 							type = bunker
-							level = 1
+							level = 5
 							province = 6488
+							instant_build = yes
+						}
+					}
+				}
+				if = {
+					limit = {
+						ROOT = { controls_province = 589 }
+					}
+					922 = {
+						add_building_construction = {
+							type = bunker
+							level = 5
+							province = 589
+							instant_build = yes
+						}
+					}
+				}
+				if = {
+					limit = {
+						ROOT = { controls_province = 6568 }
+					}
+					923 = {
+						add_building_construction = {
+							type = bunker
+							level = 5
+							province = 6568
+							instant_build = yes
+						}
+					}
+				}
+				if = {
+					limit = {
+						ROOT = { controls_province = 3530 }
+					}
+					923 = {
+						add_building_construction = {
+							type = bunker
+							level = 5
+							province = 3530
+							instant_build = yes
+						}
+					}
+				}
+				if = {
+					limit = {
+						ROOT = { controls_province = 6542 }
+					}
+					923 = {
+						add_building_construction = {
+							type = bunker
+							level = 5
+							province = 6542
+							instant_build = yes
+						}
+					}
+				}
+				if = {
+					limit = {
+						ROOT = { controls_province = 6712 }
+					}
+					923 = {
+						add_building_construction = {
+							type = bunker
+							level = 5
+							province = 6712
+							instant_build = yes
+						}
+					}
+				}
+				if = {
+					limit = {
+						ROOT = { controls_province = 11640 }
+					}
+					923 = {
+						add_building_construction = {
+							type = bunker
+							level = 5
+							province = 11640
 							instant_build = yes
 						}
 					}
@@ -4596,7 +4793,7 @@ focus_tree = {
 							}
 							add_building_construction = {
 								type = bunker
-								level = 2
+								level = 10
 								province = 6521
 								instant_build = yes
 							}
@@ -4607,7 +4804,7 @@ focus_tree = {
 							}
 							add_building_construction = {
 								type = bunker
-								level = 1
+								level = 10
 								province = 11444
 								instant_build = yes
 							}
@@ -4618,7 +4815,7 @@ focus_tree = {
 							}
 							add_building_construction = {
 								type = bunker
-								level = 1
+								level = 10
 								province = 11505
 								instant_build = yes
 							}
@@ -4629,8 +4826,19 @@ focus_tree = {
 							}
 							add_building_construction = {
 								type = bunker
-								level = 1
+								level = 10
 								province = 9428
+								instant_build = yes
+							}
+						}
+						if = {
+							limit = {
+								ROOT = { controls_province = 3499 }
+							}
+							add_building_construction = {
+								type = bunker
+								level = 10
+								province = 3499
 								instant_build = yes
 							}
 						}
@@ -8000,29 +8208,25 @@ focus_tree = {
 				}
 			}
 		}
-		completion_reward = { #this really needs better code - SpicyAlfredo
-			5 = {
+		completion_reward = { #this has  better code - EndSieg
+		63 = {
 				add_building_construction = {
-					type = infrastructure
+					type = supply_node
 					level = 1
-					instant_build = yes
-				}
-				add_building_construction = {
-					type = air_base
-					level = 1
+					province = 11288
 					instant_build = yes
 				}
 			}
-			63 = {
-				add_building_construction = {
-					type = infrastructure
-					level = 1
-					instant_build = yes
+			build_railway = { #
+				level = 5
+				path = {
+					6521 11505 9496 537 6236 9387 9252 11260 11288
 				}
-				add_building_construction = {
-					type = air_base
-					level = 1
-					instant_build = yes
+			}
+			build_railway = { #
+				level = 5
+				path = {
+					6521 11505 9496 3572 6595 552 9570 6462 9511 11467
 				}
 			}
 			68 = {
@@ -8033,7 +8237,31 @@ focus_tree = {
 				}
 				add_building_construction = {
 					type = air_base
+					level = 4
+					instant_build = yes
+				}
+			}
+			66 = {
+				add_building_construction = {
+					type = infrastructure
 					level = 1
+					instant_build = yes
+				}
+				add_building_construction = {
+					type = air_base
+					level = 2
+					instant_build = yes
+				}
+			}
+			67 = {
+				add_building_construction = {
+					type = infrastructure
+					level = 1
+					instant_build = yes
+				}
+				add_building_construction = {
+					type = air_base
+					level = 4
 					instant_build = yes
 				}
 			}
@@ -10116,7 +10344,7 @@ focus_tree = {
 	focus = {
 		id = GER_foreign_volunteers
 		icon = GFX_goal_generic_multinational_army
-		cost = 5
+		cost = 10
 		prerequisite = {
 			focus = GER_combine_SS_gestapo
 		}

--- a/common/national_focus/netherlands_MtG.txt
+++ b/common/national_focus/netherlands_MtG.txt
@@ -302,7 +302,7 @@ focus_tree = {
 		x = -1
 		y = 1
 		relative_position_id = HOL_antilles_defenses
-		cost = 5
+		cost = 10
 
 		available_if_capitulated = yes
 
@@ -344,7 +344,7 @@ focus_tree = {
 		x = 3
 		y = 1
 		relative_position_id = HOL_obtain_foreign_colonial_investments
-		cost = 10
+		cost = 5
 
 		available_if_capitulated = yes
 
@@ -406,7 +406,7 @@ focus_tree = {
 		x = 0
 		y = 1
 		relative_position_id = HOL_the_crown_jewel_colony
-		cost = 10
+		cost = 5
 
 		available_if_capitulated = yes
 
@@ -622,10 +622,10 @@ focus_tree = {
 							}
 						}
 					}
-					add_extra_state_shared_building_slots = 1
+					add_extra_state_shared_building_slots = 2
 					add_building_construction = {
 						type = industrial_complex
-						level = 1
+						level = 2
 						instant_build = yes
 					}
 				}
@@ -703,7 +703,7 @@ focus_tree = {
 		x = 1
 		y = 1
 		relative_position_id = HOL_java
-		cost = 10
+		cost = 5
 
 		available_if_capitulated = yes
 
@@ -813,7 +813,7 @@ focus_tree = {
 		x = 2
 		y = 3
 		relative_position_id = HOL_the_crown_jewel_colony
-		cost = 10
+		cost = 5
 
 		available_if_capitulated = yes
 		
@@ -945,7 +945,7 @@ focus_tree = {
 		x = 1
 		y = 1
 		relative_position_id = HOL_continue_the_war_in_batavia
-		cost = 10
+		cost = 5
 
 		available_if_capitulated = yes
 
@@ -957,7 +957,7 @@ focus_tree = {
 				}
 				add_state_modifier = {
 					modifier = {
-						local_non_core_manpower = 0.25
+						local_non_core_manpower = 0.5
 					}
 				}
 			}
@@ -1253,14 +1253,14 @@ focus_tree = {
 		x = 0
 		y = 1
 		relative_position_id = HOL_prepare_for_our_return
-		cost = 10
+		cost = 5
 
 		available_if_capitulated = yes
 
 		completion_reward = {
 			set_capital = { state = 7 }
 			add_stability = 0.1
-			add_war_support = 0.05
+			add_war_support = 0.1
 			add_manpower = 150000
 			add_equipment_to_stockpile = {
 			    type = infantry_equipment
@@ -1552,7 +1552,7 @@ focus_tree = {
 				category = industry
 			}
 			7 = {
-				add_extra_state_shared_building_slots = 1
+				add_extra_state_shared_building_slots = 4
 				add_building_construction = {
 					type = industrial_complex
 					level = 1
@@ -1568,7 +1568,7 @@ focus_tree = {
 				add_extra_state_shared_building_slots = 4
 				add_building_construction = {
 					type = infrastructure
-					level = 2
+					level = 1
 					instant_build = yes
 				}
 			}
@@ -2499,12 +2499,12 @@ focus_tree = {
 		x = -1
 		y = 1
 		relative_position_id = HOL_overturn_military_budget_cuts
-		cost = 10
+		cost = 5
 
 		available_if_capitulated = yes
 
 		completion_reward = {
-			army_experience = 10
+			army_experience = 5
 			add_doctrine_cost_reduction = {
 				name = HOL_appoint_new_supreme_commander
 				cost_reduction = 0.5
@@ -2689,7 +2689,7 @@ focus_tree = {
 			}
 		}
 		relative_position_id = HOL_modernize_our_infantry_equipment
-		cost = 10
+		cost = 5
 
 		available_if_capitulated = yes
 
@@ -2822,7 +2822,7 @@ focus_tree = {
 		x = 4
 		y = 2
 		relative_position_id = HOL_overturn_military_budget_cuts
-		cost = 10
+		cost = 5
 
 		available_if_capitulated = yes
 
@@ -3000,7 +3000,7 @@ focus_tree = {
 		x = 0
 		y = 1
 		relative_position_id = HOL_modernize_the_air_fleet
-		cost = 10
+		cost = 5
 
 		available_if_capitulated = yes
 
@@ -3092,7 +3092,7 @@ focus_tree = {
 		x = 1
 		y = 1
 		relative_position_id = HOL_strategic_bombing_defense
-		cost = 10
+		cost = 5
 
 		available_if_capitulated = yes
 
@@ -3292,10 +3292,10 @@ focus_tree = {
 
 		completion_reward = {
 			7 = {
-				add_extra_state_shared_building_slots = 1
+				add_extra_state_shared_building_slots = 3
 				add_building_construction = {
 					type = fuel_silo
-					level = 1
+					level = 3
 					instant_build = yes
 				}
 			}
@@ -3310,7 +3310,7 @@ focus_tree = {
 		x = 0
 		y = 1
 		relative_position_id = HOL_prepare_naval_expansion
-		cost = 10
+		cost = 5
 
 		available_if_capitulated = yes
 
@@ -3481,7 +3481,7 @@ focus_tree = {
 		x = 1
 		y = 1
 		relative_position_id = HOL_air_cover_for_the_new_fleet
-		cost = 10
+		cost = 5
 
 		available_if_capitulated = yes
 
@@ -3916,7 +3916,7 @@ focus_tree = {
 		x = -1
 		y = 1
 		relative_position_id = HOL_join_germany
-		cost = 10
+		cost = 5
 
 		available_if_capitulated = yes
 
@@ -6394,7 +6394,7 @@ focus_tree = {
 		x = 0
 		y = 2
 		relative_position_id = HOL_de_vaarplicht
-		cost = 10
+		cost = 5
 
 		available_if_capitulated = yes
 
@@ -6429,7 +6429,7 @@ focus_tree = {
 		x = 1
 		y = 1
 		relative_position_id = HOL_go_with_britain
-		cost = 10
+		cost = 5
 
 		available_if_capitulated = yes
 
@@ -6963,7 +6963,7 @@ focus_tree = {
 		x = 0
 		y = 1
 		relative_position_id = HOL_lessons_from_the_low_countries
-		cost = 10
+		cost = 5
 
 		available_if_capitulated = yes
 

--- a/common/national_focus/r56_australia.txt
+++ b/common/national_focus/r56_australia.txt
@@ -2379,10 +2379,10 @@ focus_tree = {
 		completion_reward = {
 			random_owned_controlled_state = {
 				prioritize = { 517 285 }
-				add_extra_state_shared_building_slots = 1
+				add_extra_state_shared_building_slots = 3
 				add_building_construction = {
 					type = fuel_silo
-					level = 1
+					level = 3
 					instant_build = yes
 				}
 			}
@@ -4814,7 +4814,7 @@ focus_tree = {
 		available = {
 			OR = {
 				has_war = yes
-				threat > 0.45
+				threat > 0.30
 			}
 			has_government = democratic
 		}
@@ -4913,7 +4913,7 @@ focus_tree = {
 		available = {
 			OR = {
 				has_war = yes
-				threat > 0.5
+				threat > 0.35
 			}
 			has_government = democratic
 		}

--- a/common/units/equipment/modules/00_ship_modules.txt
+++ b/common/units/equipment/modules/00_ship_modules.txt
@@ -305,7 +305,7 @@ equipment_modules = {
 			hg_armor_piercing = 36
 		}
 		build_cost_resources = {
-			steel = 1
+			steel = 2
 		}
 		can_convert_from = {
 			module_category = ship_heavy_battery

--- a/common/units/equipment/modules/00_ship_modules.txt
+++ b/common/units/equipment/modules/00_ship_modules.txt
@@ -337,7 +337,7 @@ equipment_modules = {
 			hg_armor_piercing = 40
 		}
 		build_cost_resources = {
-			steel = 1
+			steel = 3
 		}
 		can_convert_from = {
 			module_category = ship_heavy_battery
@@ -371,7 +371,7 @@ equipment_modules = {
 			hg_armor_piercing = 43
 		}
 		build_cost_resources = {
-			steel = 1
+			steel = 3
 			chromium = 1
 		}
 		can_convert_from = {

--- a/events/Britain.txt
+++ b/events/Britain.txt
@@ -328,7 +328,9 @@ country_event = {
 			expire = "1965.1.1"
 			ideology = conservatism
 			traits = {
+				viceroy_emeritus
 				tenacious_negotiator
+				cautious_arbiter
 			}
 		}
 	}

--- a/localisation/english/replace/r56_modifiers_l_english.yml
+++ b/localisation/english/replace/r56_modifiers_l_english.yml
@@ -12,6 +12,9 @@ l_english:
  modifier_production_speed_aluminum_mill_factor:0 "§YAluminium Mill§! construction speed"
  modifier_production_speed_rubber_refinery_factor:0 "§YRubber Refinery§! construction speed"
  modifier_state_production_speed_nuclear_reactor_factor:0 "Local §YNuclear Reactor§! Construction Speed" 
+ modifier_state_production_speed_anti_air_building_factor:0 "§YAnti-Air§! Construction Speed" 
+ modifier_state_repair_speed_anti_air_building_factor:0 "§YAnti-Air§! Repair Speed" 
+ modifier_state_repair_speed_bunker_factor:0 "§YLand Fort§! Repair Speed" 
  darien_gap:0 "Darién Gap"
  quebec_conscription_crisis:0 "Quebec Conscription Crisis"
  quebec_conscription_crisis_compromise:0 "Quebec Conscription Compromise"
@@ -43,7 +46,12 @@ modifier_experience_gain_bicycle_battalion_combat_factor:0 "§YBicycle Infantry�
  modifier_experience_gain_medium_armor_combat_factor:0 "§YMedium Tank§! combat experience gain"
  modifier_experience_gain_heavy_armor_training_factor:0 "§YHeavy Tank§! training experience gain"
  modifier_experience_gain_heavy_armor_combat_factor:0 "§YHeavy Tank§! combat experience gain"
+ modifier_experience_gain_medium_sp_artillery_brigade_combat_factor:0 "§YMedium SP Artillery§! combat experience gain"
+ modifier_experience_gain_anti_tank_combat_factor:0 "§YAnti Tank Brigade§! combat experience gain"
+ modifier_experience_gain_shocktroop_combat_factor:0 "§YShocktroops§! combat experience gain"
+ modifier_experience_gain_artillery_combat_factor:0 "§YArtillery Brigade§! combat experience gain" #Vanilla override
 
+ modifier_experience_gain_cas_training_factor:0 "§YClose Air Support§! training experience gain"
 
 modifier_experience_gain_transport_plane_training_factor:0 "§YTransport Plane§! training experience gain"
 modifier_experience_gain_transport_plane_combat_factor:0 "§YTransport Plane§! combat experience gain"


### PR DESCRIPTION
-Base game changes added for XP, advisors, and Traits
-New traits for Aussie and Lord Edward hallifax
-Cannons now require more steel as tech goes up
-Touched up German EndSieg, and German naval companies
-German Leaders updated with companies to match what they were historically
-Peacetime training no longer has XP.
-Netherlands had some focus times reduced due to weaker focuses
-Italy navy nerfed for subs, Italy will have a much harder time building subs if going after a surface fleet