### PR TITLE
TCDTF Romania Fixes

### DIFF
--- a/common/country_leader/00_traits.txt
+++ b/common/country_leader/00_traits.txt
@@ -844,15 +844,47 @@ leader_traits = {
 
 	camarilla_leader = {
 		random = no
-		political_advisor_cost_factor = -0.25
-		trade_laws_cost_factor = -0.25
+		#political_advisor_cost_factor = -0.25
+		#trade_laws_cost_factor = -0.25
+		#mobilization_laws_cost_factor = -0.25
+		#economy_cost_factor = -0.25
+		#high_command_cost_factor = -0.25
+		#air_chief_cost_factor = -0.25
+		#army_chief_cost_factor = -0.25
+		#navy_chief_cost_factor = -0.25
+		
+		r56i_laws_category_security_cost_factor = -0.25
+		r56i_laws_leadership_cost_factor = -0.25
+		r56i_laws_category_gender_cost_factor = -0.25
+		r56i_laws_social_cost_factor = -0.25
+		r56i_laws_war_cost_factor = -0.25
+		press_laws_cost_factor = -0.25
+		finances_cost_factor = -0.25
+		nationalization_cost_factor = -0.25
+		war_bonds_cost_factor = -0.25
+		equality_cost_factor = -0.25
+		mass_media_cost_factor = -0.25
+		population_cost_factor = -0.25
 		mobilization_laws_cost_factor = -0.25
+		recruitment_standard_laws_cost_factor = -0.25
+		service_limit_laws_cost_factor = -0.25
+		minimum_age_laws_cost_factor = -0.25
+		maximum_age_laws_cost_factor = -0.25
+		role_of_women_laws_cost_factor = -0.25
+		trade_laws_cost_factor = -0.25
 		economy_cost_factor = -0.25
-		high_command_cost_factor = -0.25
-		air_chief_cost_factor = -0.25
+		political_advisor_cost_factor = -0.25
+		tank_manufacturer_cost_factor = -0.25
+		naval_manufacturer_cost_factor = -0.25
+		aircraft_manufacturer_cost_factor = -0.25
+		materiel_manufacturer_cost_factor = -0.25
+		industrial_concern_cost_factor = -0.25
+		theorist_cost_factor = -0.25
 		army_chief_cost_factor = -0.25
 		navy_chief_cost_factor = -0.25
-		
+		air_chief_cost_factor = -0.25
+		high_command_cost_factor = -0.25
+
 		ai_will_do = {
 			factor = 1
 		}

--- a/common/national_focus/romania.txt
+++ b/common/national_focus/romania.txt
@@ -2731,7 +2731,7 @@ focus_tree = {
 	focus = {
 		id = ROM_his_majestys_loyal_government
 		icon = GFX_goal_ROM_his_majesty_loyal_government
-		prerequisite = { focus = ROM_fortify_the_borders }
+		#prerequisite = { focus = ROM_fortify_the_borders }
 		
 		prerequisite = { focus = ROM_revise_the_constitution }
 		mutually_exclusive = { focus = ROM_flexible_foreign_policy }
@@ -2746,30 +2746,30 @@ focus_tree = {
 		}
 
 		available = {
-			OR = {
-				has_country_flag = ROM_HUN_aligned
-				HUN = {
-					OR = {
-						is_subject_of = ROM 
-						is_ai = no
-					}
-					}
-				AND = {
-					HUN = { exists = no }
-					ROM = {
-						owns_state = 155
-						owns_state = 154
-						owns_state = 913
-						owns_state = 43
-					}
-				}
-			}
 			is_subject = no
 			has_government = neutrality
 			custom_trigger_tooltip = {
 				tooltip = ROM_carol_current_leader_trigger
 				has_country_leader = { ruling_only = yes name = "Carol II" }
 			}
+			#OR = {
+			#	has_country_flag = ROM_HUN_aligned
+			#	HUN = {
+			#		OR = {
+			#			is_subject_of = ROM 
+			#			is_ai = no
+			#		}
+			#		}
+			#	AND = {
+			#		HUN = { exists = no }
+			#		ROM = {
+			#			owns_state = 155
+			#			owns_state = 154
+			#			owns_state = 913
+			#			owns_state = 43
+			#		}
+			#	}
+			#}
 		}
 
 


### PR DESCRIPTION
- With eco and political tree disconnected and more encouragement of balkan cooperation no longer requiring nonaligned romania to own hungary is a QoL change.
- Camarillo leader expanded to apply to the rest of road to 56 add on government slots like we did with the eu4 idea of government policy
- Fort construction speed focus not required to be taken early into game now.