### PR TITLE
Italy 

### DIFF
--- a/common/characters/ITA.txt
+++ b/common/characters/ITA.txt
@@ -1333,7 +1333,7 @@ characters={
 				ITA_is_italian_tag = yes
 			}
 			available  = {
-				has_completed_focus = ITA_strengthen_the_coalition
+				#has_completed_focus = ITA_strengthen_the_coalition
 				if  = {
 					limit  = {
 						has_dlc = "Man the Guns"
@@ -1342,7 +1342,7 @@ characters={
 						has_autonomy_state  = autonomy_supervised_state
 					}
 				}
-				ITA_is_going_antifascist_in_bba = yes	#vanilla checks here:
+				#ITA_is_going_antifascist_in_bba = yes	#vanilla checks here:
 				NOT = { 
 					has_country_leader = {
 						character = ITA_ivanoe_bonomi

--- a/common/ideas/italy.txt
+++ b/common/ideas/italy.txt
@@ -1000,7 +1000,8 @@ ideas = {
 			}
 					
 			modifier = {
-				consumer_goods_factor = -0.03
+				consumer_goods_factor = 0.03
+				production_speed_buildings_factor = 0.05
 			}
 		}
 
@@ -1021,6 +1022,7 @@ ideas = {
 				consumer_goods_factor = -0.05
 				political_power_factor = -0.15
 				out_of_supply_factor = -0.1
+				production_speed_buildings_factor = 0.05
 			}
 		}
 
@@ -1965,6 +1967,18 @@ ideas = {
 			modifier = {
 				root_out_resistance_effectiveness_factor = 0.15
 				intelligence_agency_defense = 0.1
+			}
+		}
+
+		ITA_civil_war_buff = {
+			removal_cost = -1
+
+			picture = generic_mountain_warfare
+
+			modifier = {
+				army_core_attack_factor = 0.15
+				army_core_defence_factor = 0.15
+				army_morale_factor = 0.10
 			}
 		}
 

--- a/common/ideas/sooo_ideas.txt
+++ b/common/ideas/sooo_ideas.txt
@@ -29,6 +29,21 @@ ideas = {
 				can_create_factions = yes
 				can_send_volunteers = yes
 			}
-		}		
+		}	
+		sooo_Day_one_production = {
+			picture = generic_production_bonus
+
+			removal_cost = -1
+
+			modifier = {
+				production_factory_start_efficiency_factor = 0.4
+				production_factory_efficiency_gain_factor = 0.4
+				line_change_production_efficiency_factor = 0.4
+				#industrial_capacity_factory = 1
+				#production_factory_max_efficiency_factor = 1
+				#production_lack_of_resource_penalty_factor = -0.50
+			}
+		}
+
 	}
 }

--- a/common/national_focus/ethiopia.txt
+++ b/common/national_focus/ethiopia.txt
@@ -7625,7 +7625,6 @@ focus_tree = {
 			is_subject_of = ITA
 			ITA = {
 				has_civil_war = no
-				has_government = fascism
 			}
 		}
 
@@ -7819,7 +7818,6 @@ focus_tree = {
 			is_subject_of = ITA
 			ITA = {
 				has_civil_war = no
-				has_government = fascism
 			}
 		}
 
@@ -7842,7 +7840,6 @@ focus_tree = {
 			is_subject_of = ITA
 			ITA = {
 				has_civil_war = no
-				has_government = fascism
 			}
 		}
 
@@ -7954,7 +7951,6 @@ focus_tree = {
 			is_subject_of = ITA
 			ITA = {
 				has_civil_war = no
-				has_government = fascism
 			}
 		}
 
@@ -7979,7 +7975,6 @@ focus_tree = {
 			is_subject_of = ITA
 			ITA = {
 				has_civil_war = no
-				has_government = fascism
 			}
 		}
 
@@ -8164,7 +8159,6 @@ focus_tree = {
 			is_subject_of = ITA
 			ITA = {
 				has_civil_war = no
-				has_government = fascism
 			}
 		}
 
@@ -8342,7 +8336,6 @@ focus_tree = {
 			is_subject_of = ITA
 			ITA = {
 				has_civil_war = no
-				has_government = fascism
 			}
 		}
 
@@ -8382,7 +8375,6 @@ focus_tree = {
 			is_subject_of = ITA
 			ITA = {
 				has_civil_war = no
-				has_government = fascism
 			}
 		}
 
@@ -8455,7 +8447,6 @@ focus_tree = {
 			is_subject_of = ITA
 			ITA = {
 				has_civil_war = no
-				has_government = fascism
 			}
 		}
 

--- a/common/national_focus/italy.txt
+++ b/common/national_focus/italy.txt
@@ -2083,6 +2083,7 @@ focus_tree = {
 			# Tripoli - Tobruk
 			build_railway = {
 				path = { 1149 4194 7209 9980 1118 1041 4047 10046 10117 12088 4057 1198 1127 4120 11954 10123 12094 4151 1204 7082 9992 1130 }
+				level = 5
 			}
 
 			custom_effect_tooltip = ITA_libyan_railway_state_modifier_tt
@@ -3688,16 +3689,19 @@ focus_tree = {
 			#Roma - La Spezia
 			build_railway = {
 				path = { 9904 11751 6862 6875 11833 6946 6973 }
+				level = 5
 			}
 
 			#Roma - Bologna
 			build_railway = {
 				path = { 11751 6862 9750 9879 9907 1616 6985 6606 }
+				level = 5
 			}
 
 			#Roma - Napoli
 			build_railway = {
 				path = { 9904 11846 923 9826 819 }
+				level = 5
 			}
 		}
 	}
@@ -8448,7 +8452,7 @@ focus_tree = {
 		available = {
 			custom_trigger_tooltip = {
 				tooltip = ITA_solid_progress_completion_tt
-				always = no
+				always = yes
 			}
 		}
 
@@ -9494,7 +9498,7 @@ focus_tree = {
 		x = -1
 		y = 1
 		relative_position_id = ITA_triumph_in_africa_bba
-		cost = 5
+		cost = 1
 
 		bypass = {
 			NOT = { has_country_flag = SUEZ_SANCTIONS_FLAG }
@@ -9543,7 +9547,7 @@ focus_tree = {
 		x = 1
 		y = 1
 		relative_position_id = ITA_triumph_in_africa_bba
-		cost = 5
+		cost = 1
 		available = {
 			has_full_control_of_state = 835
 			has_full_control_of_state = 836
@@ -9666,7 +9670,7 @@ focus_tree = {
 		x = 3
 		y = 1
 		relative_position_id = ITA_triumph_in_africa_bba
-		cost = 5
+		cost = 1
 		available = {
 			custom_trigger_tooltip = {
 				tooltip = ITA_all_eth_initial_states_controlled_tt
@@ -10062,7 +10066,7 @@ focus_tree = {
 		x = 0
 		y = 5
 		relative_position_id = ITA_la_battaglia_per_le_nascite
-		cost = 10
+		cost = 5
 		available = {
 			has_country_leader = {
 				character = ITA_benito_mussolini
@@ -10265,7 +10269,7 @@ focus_tree = {
 		x = 0
 		y = 2
 		relative_position_id = ITA_believe_obey_fight
-		cost = 10
+		cost = 5
 
 		allow_branch = {
 			OR = {
@@ -10328,7 +10332,7 @@ focus_tree = {
 		x = 0
 		y = 2
 		relative_position_id = ITA_banda_carita
-		cost = 10
+		cost = 5
 
 		allow_branch = {
 			has_dlc = "La Resistance"
@@ -10445,7 +10449,7 @@ focus_tree = {
 			}
 		}
 
-		cost = 10
+		cost = 5
 		available = {
 			has_government = fascism
 			ITA_has_disbanded_blackshirts = no
@@ -10467,7 +10471,7 @@ focus_tree = {
 		x = 2
 		y = 0
 		relative_position_id = ITA_battaglioni_d_assalto
-		cost = 10
+		cost = 5
 		available = {
 			has_government = fascism
 			any_owned_state = {
@@ -10523,7 +10527,7 @@ focus_tree = {
 		x = 1
 		y = 2
 		relative_position_id = ITA_battaglioni_d_assalto
-		cost = 10
+		cost = 5
 		available = {
 			has_government = fascism
 			ITA_has_disbanded_blackshirts = no
@@ -11622,7 +11626,7 @@ focus_tree = {
 		x = 5
 		y = 1
 
-		cost = 10
+		cost = 5
 		
 
 		search_filters = {FOCUS_FILTER_INDUSTRY FOCUS_FILTER_BALANCE_OF_POWER}
@@ -11665,7 +11669,7 @@ focus_tree = {
 		x = 2
 		y = 0
 
-		cost = 10
+		cost = 5
 		
 
 		search_filters = {FOCUS_FILTER_POLITICAL FOCUS_FILTER_WAR_SUPPORT FOCUS_FILTER_STABILITY FOCUS_FILTER_BALANCE_OF_POWER}
@@ -11763,7 +11767,7 @@ focus_tree = {
 		x = -1
 		y = 1
 
-		cost = 10
+		cost = 5
 		available = {
 			has_government = fascism
 			power_balance_value = {
@@ -11814,7 +11818,7 @@ focus_tree = {
 		x = 0
 		y = 2
 
-		cost = 10
+		cost = 5
 		
 		search_filters = {FOCUS_FILTER_POLITICAL}
 
@@ -11835,7 +11839,7 @@ focus_tree = {
 		x = 1
 		y = 1
 
-		cost = 10
+		cost = 5
 		available = {
 			has_government = fascism
 			power_balance_value = {
@@ -11887,7 +11891,7 @@ focus_tree = {
 		x = 0
 		y = 1
 
-		cost = 10
+		cost = 5
 		
 		search_filters = {FOCUS_FILTER_POLITICAL}
 
@@ -11985,7 +11989,7 @@ focus_tree = {
 		x = -1
 		y = 2
 
-		cost = 10
+		cost = 5
 		available = {
 			has_completed_focus = ITA_stop_the_squandering
 		}
@@ -12018,7 +12022,7 @@ focus_tree = {
 		y = 2		
 		relative_position_id = ITA_italo_balbo_focus
 
-		cost = 10		
+		cost = 5		
 
 		search_filters = {FOCUS_FILTER_AIR_XP FOCUS_FILTER_INDUSTRY FOCUS_FILTER_BALANCE_OF_POWER}
 
@@ -12045,7 +12049,7 @@ focus_tree = {
 		x = 1
 		y = 1
 
-		cost = 10
+		cost = 5
 		
 
 		completion_reward = {
@@ -12091,7 +12095,7 @@ focus_tree = {
 		x = 3
 		y = 2
 
-		cost = 10
+		cost = 5
 		available = {
 			OR = {
 				any_controlled_state = {
@@ -12609,7 +12613,7 @@ focus_tree = {
 		x = 2
 		y = 1
 
-		cost = 10
+		cost = 5
 		available = {
 			is_subject = no
 			ENG = { 
@@ -12680,7 +12684,7 @@ focus_tree = {
 		x = 2
 		y = 0
 
-		cost = 10
+		cost = 5
 		available = {
 			is_subject = no
 			FRA = { 
@@ -12751,7 +12755,7 @@ focus_tree = {
 		x = 1
 		y = 2
 
-		cost = 10
+		cost = 5
 		available = {
 			is_subject = no
 			OR = { #ADD A TOOLTIP INSTEAD??
@@ -12869,7 +12873,7 @@ focus_tree = {
 		x = -1
 		y = 2
 
-		cost = 10
+		cost = 5
 		available = {
 			power_balance_value = {
 				id = ITA_power_balance
@@ -12895,7 +12899,7 @@ focus_tree = {
 		x = 0
 		y = 2
 
-		cost = 10
+		cost = 5
 		available = {
 			power_balance_value = {
 				id = ITA_power_balance
@@ -12955,7 +12959,7 @@ focus_tree = {
 		x = 2
 		y = 1
 
-		cost = 10
+		cost = 5
 		
 
 		search_filters = {FOCUS_FILTER_INDUSTRY}
@@ -12976,7 +12980,7 @@ focus_tree = {
 		x = 0
 		y = 1
 
-		cost = 10
+		cost = 5
 		
 		search_filters = {FOCUS_FILTER_INDUSTRY}
 
@@ -13161,7 +13165,7 @@ focus_tree = {
 		x = -2
 		y = 1
 		relative_position_id = ITA_monarchia_d_italia
-		cost = 10
+		cost = 5
 
 		search_filters = {FOCUS_FILTER_INDUSTRY}
 
@@ -14118,7 +14122,7 @@ focus_tree = {
 		x = 1
 		y = 1
 		relative_position_id = ITA_disband_the_blackshirts
-		cost = 10
+		cost = 5
 
 		search_filters = {FOCUS_FILTER_ARMY_XP FOCUS_FILTER_POLITICAL FOCUS_FILTER_MANPOWER}
 
@@ -14274,7 +14278,7 @@ focus_tree = {
 		x = 1
 		y = 1
 		relative_position_id = ITA_expand_the_royal_guard
-		cost = 10
+		cost = 5
 
 		completion_reward = {
 			custom_effect_tooltip = ITA_paramilitary_training_re_tt
@@ -14424,7 +14428,7 @@ focus_tree = {
 		x = -1
 		y = 2
 		relative_position_id = ITA_gloria_al_regno_d_italia
-		cost = 10
+		cost = 5
 
 		search_filters = {FOCUS_FILTER_WAR_SUPPORT FOCUS_FILTER_ARMY_XP FOCUS_FILTER_AIR_XP FOCUS_FILTER_NAVY_XP FOCUS_FILTER_STABILITY FOCUS_FILTER_MANPOWER}
 
@@ -14949,7 +14953,7 @@ focus_tree = {
 		x = 4
 		y = 2
 		relative_position_id = ITA_mare_nostrum_bba
-		cost = 5
+		cost = 10
 		available = {
 			is_subject = no
 			any_country = {
@@ -15610,7 +15614,7 @@ focus_tree = {
 		x = 1
 		y = 1
 		relative_position_id = ITA_foreign_affairs
-		cost = 2	#rather short so I dont have to weirdly change historical AI
+		cost = 1	#rather short so I dont have to weirdly change historical AI
 		
 		available = {
 			is_subject = no
@@ -20309,7 +20313,7 @@ focus_tree = {
 		x = 2
 		y = 2
 		relative_position_id = ITA_unite_the_opposition
-		cost = 5
+		cost = 1
 
 		allow_branch = {
 			has_dlc = "By Blood Alone"
@@ -20485,7 +20489,7 @@ focus_tree = {
 		x = -1
 		y = 1
 		relative_position_id = ITA_defy_the_duce
-		cost = 5
+		cost = 1
 		available = {
 			has_civil_war = yes
 		}
@@ -20516,7 +20520,7 @@ focus_tree = {
 		x = 1
 		y = 1
 		relative_position_id = ITA_defy_the_duce
-		cost = 5
+		cost = 1
 		available = {
 			has_civil_war = yes
 			has_full_control_of_state = 162 #TOSCANA -> La Spezia, where railway guns were stored.
@@ -21033,7 +21037,7 @@ focus_tree = {
 		search_filters = {FOCUS_FILTER_INDUSTRY FOCUS_FILTER_BALANCE_OF_POWER}
 
 		completion_reward = {
-			add_stability = -0.15
+			add_stability = -0.05
 
 			custom_effect_tooltip = ITA_industrial_socialization_factories_tt
 			hidden_effect = {
@@ -21152,7 +21156,7 @@ focus_tree = {
 		x = 0
 		y = 1
 		relative_position_id = ITA_institute_the_five_year_plan
-		cost = 10
+		cost = 5
 
 		search_filters = {FOCUS_FILTER_INDUSTRY}
 
@@ -21179,7 +21183,7 @@ focus_tree = {
 		x = 2
 		y = 1
 		relative_position_id = ITA_industrial_socialization
-		cost = 10
+		cost = 5
 
 		search_filters = {FOCUS_FILTER_ARMY_XP FOCUS_FILTER_AIR_XP FOCUS_FILTER_NAVY_XP FOCUS_FILTER_POLITICAL FOCUS_FILTER_BALANCE_OF_POWER}
 
@@ -21483,7 +21487,7 @@ focus_tree = {
 		x = 0
 		y = 1
 		relative_position_id = ITA_crush_the_mafia
-		cost = 10
+		cost = 5
 
 		search_filters = {FOCUS_FILTER_ARMY_XP FOCUS_FILTER_AIR_XP FOCUS_FILTER_NAVY_XP}
 
@@ -22264,7 +22268,7 @@ focus_tree = {
 		x = -1
 		y = 1
 		relative_position_id = ITA_italian_socialism
-		cost = 10
+		cost = 5
 
 		search_filters = {FOCUS_FILTER_INDUSTRY}
 
@@ -22445,7 +22449,7 @@ focus_tree = {
 		x = 3
 		y = 1
 		relative_position_id = ITA_italian_socialism
-		cost = 10
+		cost = 5
 
 		available = {
 			has_civil_war = no
@@ -23237,7 +23241,7 @@ focus_tree = {
 		x = -1
 		y = 2
 		relative_position_id = ITA_abolish_the_colonies
-		cost = 10
+		cost = 5
 
 		search_filters = {FOCUS_FILTER_INDUSTRY}
 
@@ -23628,7 +23632,7 @@ focus_tree = {
 		x = -2
 		y = 1
 		relative_position_id = ITA_the_fight_overseas
-		cost = 10
+		cost = 5
 
 		search_filters = {FOCUS_FILTER_MANPOWER}
 
@@ -24028,7 +24032,7 @@ focus_tree = {
 		x = 2
 		y = 1
 		relative_position_id = ITA_the_fight_overseas
-		cost = 10
+		cost = 5
 
 		search_filters = {FOCUS_FILTER_MANPOWER}
 

--- a/common/national_focus/italy.txt
+++ b/common/national_focus/italy.txt
@@ -8584,7 +8584,7 @@ focus_tree = {
 			}
 		}
 		relative_position_id = ITA_solid_progress
-		cost = 5
+		cost = 4
 
 		completion_reward = {
 			if = {
@@ -13108,7 +13108,11 @@ focus_tree = {
 		relative_position_id = ITA_depose_mussolini
 		cost = 5
 		available = {
+			#neutrality > 0.25
+         OR = {
+			democratic > 0.25
 			neutrality > 0.25
+		 }
 		}
 
 		search_filters = {FOCUS_FILTER_POLITICAL FOCUS_FILTER_BALANCE_OF_POWER}
@@ -16648,18 +16652,8 @@ focus_tree = {
 			is_in_faction = no
 			has_war = no
 			custom_trigger_tooltip = {
-				tooltip = ITA_germ_italy_same_tt
+				#tooltip = ITA_germ_italy_same_tt
 				GER = { has_government = ROOT }
-			}
-			GER = {
-				is_faction_leader = yes
-				is_subject = no
-				NOT = {
-					OR = {
-						has_war_with = ITA
-						has_completed_focus = GER_prepare_italian_invasion
-					}	
-				}
 			}
 			NOT = { has_country_flag = ENG_ditched_by_the_germans_flag }
 		}

--- a/common/on_actions/sooo_on_actions.txt
+++ b/common/on_actions/sooo_on_actions.txt
@@ -17,6 +17,10 @@ on_actions = {
 						NOT = { is_ai = yes }
 					}
 					add_ideas = sooo_player_was_here 
+					add_timed_idea = {
+						idea = sooo_Day_one_production
+						days = 31
+					}
 				}
 				
 			}

--- a/events/BBA_Italy.txt
+++ b/events/BBA_Italy.txt
@@ -6042,6 +6042,11 @@ country_event = {
 		ITA_civil_war_deal_with_militias = yes
 
 		ITA_anti_fascist_civil_war_deal_with_fascist_side = yes
+
+		add_timed_idea = { 
+			idea = ITA_civil_war_buff 
+			days = 180 
+		}
 	}
 	
 	#Mimimimi democratic
@@ -6065,6 +6070,11 @@ country_event = {
 		ITA_civil_war_deal_with_militias = yes
 
 		ITA_anti_fascist_civil_war_deal_with_fascist_side = yes
+
+		add_timed_idea = { 
+			idea = ITA_civil_war_buff 
+			days = 180 
+		}
 	}
 }
 

--- a/localisation/english/ITA_l_english.yml
+++ b/localisation/english/ITA_l_english.yml
@@ -44,6 +44,9 @@
 
  # Events
 
+
+ITA_civil_war_buff:0 "Italian Civil War Buff"
+ITA_civil_war_buff_desc:0 "A little boost for the player to finish the civil war faster"
  r56_italy.1.t:0 "The King Removes Mussolini from Power"
  r56_italy.1.d:0 "Following an emergency meeting requested by King Victor Emmanuel III, the King met with Mussolini, asking for his resignation, pointing, in particular, to the enormous debt in which [ITA.GetNameDef] finds itself and that the latter has not been able to resolve in almost fifteen years of power, the economic abyss that was the Ethiopian campaign, as well as the problems caused by the embargoes suffered following the invasion.\n\nUnder pressure from the Grand Council of Fascism, which began to turn against him, particularly under the influence of the royalists who tried to make a more prominent place for themselves, Mussolini had no choice but to accept the order, not wishing to face prison. Pietro Badoglio was then appointed Prime Minister. Badoglio, despite his many links with the fascist administration, is seen as a much more moderate figure.\n\nThe King is trying to save the face of [ITA.GetNameDef], whose situation is constantly falling apart."
  r56_italy.1.a:0 "Let's hope the situation can be fixed."

--- a/localisation/english/SOOO_l_english.yml
+++ b/localisation/english/SOOO_l_english.yml
@@ -7,6 +7,9 @@
  
  sooo_game_speed_balance:0 "SOO Optimization AI"
  sooo_game_speed_balance_desc:0 "This Country is not WWII country and controlled by AI. If you are a player click to called \"AI to Player\" SOO Optimization Decision."
+
+sooo_Day_one_production:0 "Day One Production"
+sooo_Day_one_production_desc:0 "This will let you change your production lines and keep efficiency on your military production rather than being punished for swapping off the base game production lines."
  
  sooo_player_to_ai_to_player:0 "SOO Optimization Decision"
  sooo_player_to_ai:0 "Player to AI"


### PR DESCRIPTION
-Added a month long production swap bonus to all player nations on jan 36
-Italian political trees shorted and streamlined to match each other in length and more QoL changes
-Italian civil war now gives player a 180 day core attack defense buff
-italian demo and commie trees touched
-rail roads upgraded from level 1 for railroad focuses
-democratic monarchist now allows you to buy a democratic advisor instead of swapping advisors mid game, ethiopia no longer punished by italy doing alt hist.