### PR TITLE
-TCDTF AI  building priority

### DIFF
--- a/common/defines/scuffed_ai_defines.lua
+++ b/common/defines/scuffed_ai_defines.lua
@@ -164,15 +164,10 @@ NDefines.NAI.GENERATE_WARGOAL_ANTAGONIZE_SCALE = 0.25 -- (Original value: 0.35) 
 --------------------------------------------------------------------------------------------------------------
 
 NDefines.NAI.BUILDING_TARGETS_BUILDING_PRIORITIES = {				-- buildings in order of pirority when considering building targets strategies. First has the greatest priority omitted has the lowest. NOTE: not all buildings are supported by building targets strategies.
-    'synthetic_refinery',
-    'fuel_silo',
+    'infrastructure',
     'industrial_complex',
     'arms_factory',
-    'infrastructure',
     'dockyard',
-    'air_base',
-    'radar_station',
-    'nuclear_reactor',
 }
 
 --------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
- Ai building priority seemed to be in a fullchord mode, set it to make more sense, similar to base game ai define but including all factory types ( infru > civ > mil > dockyard )