### PR TITLE
-TCDTF Eco laws

### DIFF
--- a/common/ideas/_economic.txt
+++ b/common/ideas/_economic.txt
@@ -91,6 +91,8 @@ ideas = {
 				max_fuel_factor = -0.5
 				fuel_gain_factor = -0.5
 				production_factory_max_efficiency_factor = -0.1
+				conversion_cost_civ_to_mil_factor= 0.30
+				conversion_cost_mil_to_civ_factor = -0.30
 				#production_factory_start_efficiency_factor = -0.1
 			}
 			
@@ -158,6 +160,8 @@ ideas = {
 				fuel_gain_factor = -0.25
 				max_fuel_factor = -0.25
 				production_factory_max_efficiency_factor = -0.05
+				conversion_cost_civ_to_mil_factor= 0.20
+				conversion_cost_mil_to_civ_factor = -0.20
 				#production_factory_start_efficiency_factor = -0.05
 			}
 			


### PR DESCRIPTION
- Civ and early mob set back to pre fullchord buff, before the reaction was to entirely remove it from retaliation to fullchords conversion 50% bonus bullshit